### PR TITLE
fix: implement --interactive flag to MultipleReader

### DIFF
--- a/CHAP/common/reader.py
+++ b/CHAP/common/reader.py
@@ -7,6 +7,7 @@ Description: Module for Writers used in multiple experiment-specific workflows.
 
 # system modules
 import argparse
+import inspect
 import json
 import logging
 import sys
@@ -28,7 +29,7 @@ class BinaryFileReader(Reader):
         return(data)
 
 class MultipleReader(Reader):
-    def read(self, readers):
+    def read(self, readers, **_read_kwargs):
         '''Return resuts from multiple `Reader`s.
 
         :param readers: a dictionary where the keys are specific names that are
@@ -50,7 +51,10 @@ class MultipleReader(Reader):
             reader = reader_class()
             reader_kwargs = reader_config[reader_name]
 
-            data.extend(reader.read(**reader_kwargs))
+            # Combine keyword arguments to MultipleReader.read with those to the reader
+            # giving precedence to those in the latter
+            combined_kwargs = {**_read_kwargs, **reader_kwargs}
+            data.extend(reader.read(**combined_kwargs))
 
         self.logger.info(f'Finished "read" in {time()-t0:.3f} seconds\n')
 

--- a/CHAP/runner.py
+++ b/CHAP/runner.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-#-*- coding: utf-8 -*-
-#pylint: disable=
 """
 File       : runner.py
 Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
@@ -57,13 +54,14 @@ def runner(opts):
     kwds = []
     for item in pipeline_config:
         # load individual object with given name from its module
+        kwargs = {'interactive': opts.interactive}
         if isinstance(item, dict):
             name = list(item.keys())[0]
-            kwargs = item[name]
+            # Combine the "interactive" command line argument with the object's keywords
+            # giving precedence of "interactive" in the latter
+            kwargs = {**kwargs, **item[name]}
         else:
             name = item
-            kwargs = {}
-        kwargs['interactive'] = opts.interactive
         modName, clsName = name.split('.')
         module = __import__(f'CHAP.{modName}', fromlist=[clsName])
         obj = getattr(module, clsName)()


### PR DESCRIPTION
Also fix CHAP/runner.py to allow the interactive flag set as either
    a command line argument or a processor keyword in the pipeline