### PR TITLE
Add support for python profile

### DIFF
--- a/CHAP/processor.py
+++ b/CHAP/processor.py
@@ -62,6 +62,8 @@ class Processor():
         if isinstance(data, list):
             if all([isinstance(d,dict) for d in data]):
                 data = data[0]['data']
+        if data == None:
+            return []
         # process operation is a simple print function
         data += "process part\n"
         # and we return data back to pipeline

--- a/CHAP/runner.py
+++ b/CHAP/runner.py
@@ -27,12 +27,23 @@ class OptionParser():
             dest="interactive", help="Allow interactive processes")
         self.parser.add_argument('--log-level', choices=logging._nameToLevel.keys(),
             dest='log_level', default='INFO', help='logging level')
+        self.parser.add_argument("--profile", action="store_true", dest="profile",
+            help="profile output")
 
 def main():
     "Main function"
     optmgr  = OptionParser()
     opts = optmgr.parser.parse_args()
-    runner(opts)
+    if opts.profile:
+        import cProfile # python profiler
+        import pstats   # profiler statistics
+        cmd  = 'runner(opts)'
+        cProfile.runctx(cmd, globals(), locals(), 'profile.dat')
+        info = pstats.Stats('profile.dat')
+        info.sort_stats('cumulative')
+        info.print_stats()
+    else:
+        runner(opts)
 
 def runner(opts):
     """


### PR DESCRIPTION
This PR provides support for profiling pipeline code via python profile, e.g.
```
cat /tmp/config.yaml
pipeline:
  - processor.Processor: {}

# run runner code with simple config
./runner.py --config /tmp/config.yaml --profile
__main__            : Input configuration: {'pipeline': [{'processor.Processor': {}}]}

__main__            : Loaded <CHAP.processor.Processor object at 0x1075c7050>
__main__            : Loaded <CHAP.pipeline.Pipeline object at 0x1075c7210> with 1 items

__main__            : Calling "execute" on <CHAP.pipeline.Pipeline object at 0x1075c7210>
Pipeline            : Executing "execute"

Pipeline            : Calling "process" on <CHAP.processor.Processor object at 0x1075c7050>
Processor           : Executing "process" with type(data)=<class 'NoneType'>
Processor           : Ignoring invalid arg to _process: interactive
Processor           : Finished "process" in 0.001 seconds

Pipeline            : Executed "execute" in 0.001 seconds
Thu Apr 20 10:10:47 2023    profile.dat

         2037 function calls (2027 primitive calls) in 0.004 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.004    0.004 {built-in method builtins.exec}
        1    0.000    0.000    0.003    0.003 <string>:1(<module>)
        1    0.000    0.000    0.003    0.003 /Users/vk/Work/CHESS/ChessAnalysisPipeline/CHAP/./runner.py:48(runner)
        1    0.000    0.000    0.001    0.001 /opt/local/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/yaml/__init__.py:117(safe_load)
        1    0.000    0.000    0.001    0.001 /opt/local/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/yaml/__init__.py:74(load)
        9    0.000    0.000    0.001    0.000 /opt/local/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py:1479(info)
       10    0.000    0.000    0.001    0.000 /opt/local/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py:1610(_log)
        1    0.000    0.000    0.001    0.001 /opt/local/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/yaml/constructor.py:47(get_single_data)
....
```
At the end you'll get `profile.dat` file as well which contains results of the profiler stats. According to [1] you may further add visualization of profiler stats.

Resources:
1. https://www.machinelearningplus.com/python/cprofile-how-to-profile-your-python-code/
2. https://docs.python.org/3/library/profile.html