### PR TITLE
add: implementations of PipelineItem and PipelineData.

### DIFF
--- a/CHAP/common/__init__.py
+++ b/CHAP/common/__init__.py
@@ -1,5 +1,4 @@
 from CHAP.common.reader import (BinaryFileReader,
-                                MultipleReader,
                                 NexusReader,
                                 URLReader,
                                 YAMLReader)
@@ -11,7 +10,6 @@ from CHAP.common.processor import (AsyncProcessor,
                                    NexusToXarrayProcessor,
                                    PrintProcessor,
                                    StrainAnalysisProcessor,
-                                   URLResponseProcessor,
                                    XarrayToNexusProcessor,
                                    XarrayToNumpyProcessor)
 from CHAP.common.writer import (ExtractArchiveWriter,

--- a/CHAP/common/processor.py
+++ b/CHAP/common/processor.py
@@ -27,7 +27,7 @@ class AsyncProcessor(Processor):
         super().__init__()
         self.mgr = mgr
 
-    def _process(self, data):
+    def process(self, data):
         """Asynchronously process the input documents with the
         `self.mgr` `Processor`.
 
@@ -67,7 +67,7 @@ class AsyncProcessor(Processor):
 class IntegrationProcessor(Processor):
     """A processor for integrating 2D data with pyFAI"""
 
-    def _process(self, data):
+    def process(self, data):
         """Integrate the input data with the integration method and
         keyword arguments supplied and return the results.
 
@@ -93,7 +93,7 @@ class IntegrateMapProcessor(Processor):
     containing a map of the integrated detector data requested.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Process the output of a `Reader` that contains a map and
         integration configuration and return a
         `nexusformat.nexus.NXprocess` containing a map of the
@@ -307,7 +307,7 @@ class MapProcessor(Processor):
     configuration.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Process the output of a `Reader` that contains a map
         configuration and return a `nexusformat.nexus.NXentry`
         representing the map.
@@ -438,7 +438,7 @@ class NexusToNumpyProcessor(Processor):
     `NXobject` into an `numpy.ndarray`.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Return the default plottable data signal in `data` as an
         `numpy.ndarray`.
 
@@ -474,7 +474,7 @@ class NexusToXarrayProcessor(Processor):
     `NXobject` into an `xarray.DataArray`.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Return the default plottable data signal in `data` as an
         `xarray.DataArray`.
 
@@ -528,7 +528,7 @@ class PrintProcessor(Processor):
     the original input data, unchanged in any way.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Print and return the input data.
 
         :param data: Input data
@@ -557,7 +557,7 @@ class StrainAnalysisProcessor(Processor):
     measured.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Process the input map detector data & configuration for the
         strain analysis procedure, and return a map of sample strains.
 
@@ -601,44 +601,12 @@ class StrainAnalysisProcessor(Processor):
         return strain_analysis_config
 
 
-class URLResponseProcessor(Processor):
-    """A Processor to decode and return data resulting from from
-    URLReader.read
-    """
-
-    def _process(self, data):
-        """Take data returned from URLReader.read and return a decoded
-        version of the content.
-
-        :param data: input data (output of URLReader.read)
-        :type data: list[dict]
-        :return: decoded data contents
-        :rtype: object
-        """
-
-        data = data[0]
-
-        content = data['data']
-        encoding = data['encoding']
-
-        self.logger.debug(
-            f'Decoding content of type {type(content)} with {encoding}')
-
-        try:
-            content = content.decode(encoding)
-        except:
-            self.logger.warning('Failed to decode content of type '
-                                f'{type(content)} with {encoding}')
-
-        return content
-
-
 class XarrayToNexusProcessor(Processor):
     """A Processor to convert the data in an `xarray` structure to an
     `nexusformat.nexus.NXdata`.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Return `data` represented as an `nexusformat.nexus.NXdata`.
 
         :param data: The input `xarray` structure
@@ -665,7 +633,7 @@ class XarrayToNumpyProcessor(Processor):
     structure to an `numpy.ndarray`.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Return just the signal values contained in `data`.
 
         :param data: The input `xarray.DataArray`

--- a/CHAP/common/reader.py
+++ b/CHAP/common/reader.py
@@ -16,7 +16,7 @@ from CHAP import Reader
 
 class BinaryFileReader(Reader):
     """Reader for binary files"""
-    def _read(self, filename):
+    def read(self, filename):
         """Return a content of a given file name
 
         :param filename: name of the binart file to read from
@@ -29,42 +29,9 @@ class BinaryFileReader(Reader):
         return data
 
 
-class MultipleReader(Reader):
-    def read(self, readers, **_read_kwargs):
-        """Return resuts from multiple `Reader`s.
-
-        :param readers: a dictionary where the keys are specific names
-            that are used by the next item in the `Pipeline`, and the
-            values are `Reader` configurations.
-        :type readers: list[dict]
-        :return: The results of calling `Reader.read(**kwargs)` for
-            each item configured in `readers`.
-        :rtype: list[dict[str,object]]
-        """
-
-        t0 = time()
-        self.logger.info(f'Executing "read" with {len(readers)} Readers')
-
-        data = []
-        for reader_config in readers:
-            reader_name = list(reader_config.keys())[0]
-            reader_class = getattr(modules[__name__], reader_name)
-            reader = reader_class()
-            reader_kwargs = reader_config[reader_name]
-
-            # Combine keyword arguments to MultipleReader.read with those to the reader
-            # giving precedence to those in the latter
-            combined_kwargs = {**_read_kwargs, **reader_kwargs}
-            data.extend(reader.read(**combined_kwargs))
-
-        self.logger.info(f'Finished "read" in {time()-t0:.3f} seconds\n')
-
-        return data
-
-
 class NexusReader(Reader):
     """Reader for NeXus files"""
-    def _read(self, filename, nxpath='/'):
+    def read(self, filename, nxpath='/'):
         """Return the NeXus object stored at `nxpath` in the nexus
         file `filename`.
 
@@ -87,7 +54,7 @@ class NexusReader(Reader):
 
 class URLReader(Reader):
     """Reader for data available over HTTPS"""
-    def _read(self, url, headers={}, timeout=10):
+    def read(self, url, headers={}, timeout=10):
         """Make an HTTPS request to the provided URL and return the
         results.  Headers for the request are optional.
 
@@ -112,7 +79,7 @@ class URLReader(Reader):
 
 class YAMLReader(Reader):
     """Reader for YAML files"""
-    def _read(self, filename):
+    def read(self, filename):
         """Return a dictionary from the contents of a yaml file.
 
         :param filename: name of the YAML file to read from

--- a/CHAP/common/writer.py
+++ b/CHAP/common/writer.py
@@ -11,10 +11,9 @@ import os
 # local modules
 from CHAP import Writer
 
-
 class ExtractArchiveWriter(Writer):
     """Writer for tar files from binary data"""
-    def _write(self, data, filename):
+    def write(self, data, filename):
         """Take a .tar archive represented as bytes in `data` and
         write the extracted archive to files.
 
@@ -30,6 +29,8 @@ class ExtractArchiveWriter(Writer):
         from io import BytesIO
         import tarfile
 
+        data = self.unwrap_pipelinedata(data)
+
         with tarfile.open(fileobj=BytesIO(data)) as tar:
             tar.extractall(path=filename)
 
@@ -38,7 +39,7 @@ class ExtractArchiveWriter(Writer):
 
 class NexusWriter(Writer):
     """Writer for NeXus files from `NXobject`-s"""
-    def _write(self, data, filename, force_overwrite=False):
+    def write(self, data, filename, force_overwrite=False):
         """Write `data` to a NeXus file
 
         :param data: the data to write to `filename`.
@@ -50,6 +51,8 @@ class NexusWriter(Writer):
         """
 
         from nexusformat.nexus import NXobject
+
+        data = self.unwrap_pipelinedata(data)
 
         if not isinstance(data, NXobject):
             raise TypeError('Cannot write object of type '
@@ -63,7 +66,7 @@ class NexusWriter(Writer):
 
 class YAMLWriter(Writer):
     """Writer for YAML files from `dict`-s"""
-    def _write(self, data, filename, force_overwrite=False):
+    def write(self, data, filename, force_overwrite=False):
         """If `data` is a `dict`, write it to `filename`.
 
         :param data: the dictionary to write to `filename`.
@@ -81,6 +84,8 @@ class YAMLWriter(Writer):
         """
 
         import yaml
+
+        data = self.unwrap_pipelinedata(data)
 
         if not isinstance(data, (dict, list)):
             raise TypeError(

--- a/CHAP/edd/processor.py
+++ b/CHAP/edd/processor.py
@@ -23,7 +23,7 @@ class MCACeriaCalibrationProcessor(Processor):
     channel energies for an EDD experimental setup.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Return tuned values for 2&theta and linear correction
         parameters for the MCA channel energies.
 
@@ -209,7 +209,7 @@ class MCADataProcessor(Processor):
     transformed according to the results of a ceria calibration.
     """
 
-    def _process(self, data):
+    def process(self, data):
         """Process configurations for a map and MCA detector(s), and
         return the calibrated MCA data collected over the map.
 

--- a/CHAP/pipeline.py
+++ b/CHAP/pipeline.py
@@ -8,6 +8,7 @@ Description:
 """
 
 # system modules
+import inspect
 import logging
 from time import time
 
@@ -34,37 +35,131 @@ class Pipeline():
         t0 = time()
         self.logger.info('Executing "execute"\n')
 
-        data = None
+        data = PipelineData()
         for item, kwargs in zip(self.items, self.kwds):
-            if hasattr(item, 'read'):
-                self.logger.info(f'Calling "read" on {item}')
-                data = item.read(**kwargs)
-            if hasattr(item, 'process'):
-                self.logger.info(f'Calling "process" on {item}')
-                data = item.process(data, **kwargs)
-            if hasattr(item, 'write'):
-                self.logger.info(f'Calling "write" on {item}')
-                data = item.write(data, **kwargs)
+            if hasattr(item, 'execute'):
+                self.logger.info(f'Calling "execute" on {item}')
+                data = item.execute(data=data, **kwargs)
 
         self.logger.info(f'Executed "execute" in {time()-t0:.3f} seconds')
 
 
-class PipelineObject():
-    """PipelineObject represent generic Pipeline class"""
-    def __init__(self, reader, writer, processor):
-        """PipelineObject class constructor"""
-        self.reader = reader
-        self.writer = writer
-        self.processor = processor
+class PipelineData(dict):
+    """Wrapper for all results of PipelineItem.execute"""
+    def __init__(self, name=None, data=None, schema=None):
+        super().__init__()
+        self.__setitem__('name', name)
+        self.__setitem__('data', data)
+        self.__setitem__('schema', schema)
 
-    def read(self, filename):
-        """read object API"""
-        return self.reader.read(filename)
 
-    def write(self, data, filename):
-        """write object API"""
-        return self.writer.write(data, filename)
+class PipelineItem():
+    """An object that can be supplied as one of the items
+    `Pipeline.items`
+    """
+    def __init__(self):
+        """Constructor of PipelineItem class"""
+        self.__name__ = self.__class__.__name__
+        self.logger = logging.getLogger(self.__name__)
+        self.logger.propagate = False
 
-    def process(self, data):
-        """process object API"""
-        return self.processor.process(data)
+    @staticmethod
+    def unwrap_pipelinedata(data):
+        """Given a list of PipelineData objects, return a list of
+        their "data" values. If there is only one item in ``data``,
+        return only its "data" value (not in a list).
+
+        :param data: input data to read, write, or process that needs
+            to be unrapped from PipelineData before use
+        :type data: list[PipelineData]
+        :return: just the "data" values of the items in ``data``
+        :rtype: Union[list[object], object]
+        """
+
+        values = [d['data'] for d in data]
+
+        if len(values) == 1:
+            return values[0]
+
+        return values
+
+    def execute(self, schema=None, **kwargs):
+        """Run the appropriate method of the object and return the
+        result.
+
+        :param schema: the name of a schema associated with the data
+            that will be returned
+        :type schema: str
+        :param kwargs: a dictionary of any positional and keyword
+            arguments to supply to the read, process, or write method.
+        :type kwargs: dict
+        :return: the wrapped result of running read, process, or write.
+        :rtype: list[PipelineData]
+        """
+
+        if hasattr(self, 'read'):
+            method_name = 'read'
+        elif hasattr(self, 'process'):
+            method_name = 'process'
+        elif hasattr(self, 'write'):
+            method_name = 'write'
+        else:
+            self.logger.error('No implementation of read, write, or process')
+
+        method = getattr(self, method_name)
+        allowed_args = inspect.getfullargspec(method).args \
+                       + inspect.getfullargspec(method).kwonlyargs
+        args = {}
+        for k, v in kwargs.items():
+            if k in allowed_args:
+                args[k] = v
+
+        t0 = time()
+        self.logger.info(f'Executing "{method_name}" with {args}')
+        data = method(**args)
+        self.logger.info(f'Finished "{method_name}" in '
+                         + f'{time()-t0:.0f} seconds\n')
+
+        return [PipelineData(name=self.__name__,
+                             data=data,
+                             schema=schema)]
+
+
+class MultiplePipelineItem(PipelineItem):
+    """An object to deliver results from multiple `PipelineItem`s to a
+    single `PipelineItem` in the `Pipeline.execute()` method.
+    """
+
+    def execute(self, items=[], **kwargs):
+        """Independently execute all items in `self.items`, then
+        return all of their results.
+
+        :param items: PipelineItem configurations
+        :type items: list
+        :rtype: list[PipelineData]
+        """
+
+        t0 = time()
+        self.logger.info(f'Executing {len(items)} PipelineItems')
+
+        results = []
+        for item_config in items:
+            if isinstance(item_config, dict):
+                item_name = list(item_config.keys())[0]
+                item_args = item_config[item_name]
+            elif isinstance(item_config, str):
+                item_name = item_config
+                item_args = {}
+            else:
+                raise RuntimeError(
+                    f'Unknown item config type {type(item_config)}')
+
+            mod_name, cls_name = item_name.rsplit('.', 1)
+            module = __import__(f'CHAP.{mod_name}', fromlist=cls_name)
+            item = getattr(module, cls_name)()
+            results.append(item.execute(**item_args, **kwargs)[0])
+
+        self.logger.info(
+            f'Finished executing {len(items)} PipelineItems in {time()-t0:.0f}'
+            ' seconds\n')
+        return results

--- a/CHAP/processor.py
+++ b/CHAP/processor.py
@@ -14,42 +14,13 @@ import logging
 from sys import modules
 from time import time
 
+# local modules
+from CHAP.pipeline import PipelineItem
 
-class Processor():
+class Processor(PipelineItem):
     """Processor represent generic processor"""
-    def __init__(self):
-        """Processor constructor"""
-        self.__name__ = self.__class__.__name__
-        self.logger = logging.getLogger(self.__name__)
-        self.logger.propagate = False
 
-    def process(self, data, **_process_kwargs):
-        """process data API
-
-        :param _process_kwargs: keyword arguments to pass to
-            `self._process`, defaults to `{}`
-        :type _process_kwargs: dict, optional
-        """
-
-        t0 = time()
-        self.logger.info(f'Executing "process" with type(data)={type(data)}')
-
-        _valid_process_args = {}
-        allowed_args = getfullargspec(self._process).args \
-            + getfullargspec(self._process).kwonlyargs
-        for k, v in _process_kwargs.items():
-            if k in allowed_args:
-                _valid_process_args[k] = v
-            else:
-                self.logger.warning(f'Ignoring invalid arg to _process: {k}')
-
-        data = self._process(data, **_valid_process_args)
-
-        self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
-
-        return data
-
-    def _process(self, data):
+    def process(self, data):
         """Private method to carry out the mechanics of the specific
         Processor.
 

--- a/CHAP/reader.py
+++ b/CHAP/reader.py
@@ -12,59 +12,14 @@ import logging
 from sys import modules
 from time import time
 
+# local modules
+from CHAP.pipeline import PipelineItem
 
-class Reader():
+
+class Reader(PipelineItem):
     """Reader represent generic file writer"""
 
-    def __init__(self):
-        """Constructor of Reader class"""
-        self.__name__ = self.__class__.__name__
-        self.logger = logging.getLogger(self.__name__)
-        self.logger.propagate = False
-
-    def read(self, type_=None, schema=None, encoding=None, **_read_kwargs):
-        """Read API
-
-        Wrapper to read, format, and return the data requested.
-
-        :param type_: the expected type of data read from `filename`,
-            defualts to `None`
-        :type type_: type, optional
-        :param schema: the expected schema of the data read from
-            `filename`, defaults to `None`
-        :type schema: str, otional
-        :param _read_kwargs: keyword arguments to pass to
-            `self._read`, defaults to `{}`
-        :type _read_kwargs: dict, optional
-        :return: list with one item: a dictionary containing the data
-            read from `filename`, the name of this `Reader`, and the
-            values of `type_` and `schema`.
-        :rtype: list[dict[str,object]]
-        """
-
-        t0 = time()
-        self.logger.info(f'Executing "read" with type={type_}, '
-                         f'schema={schema}, kwargs={_read_kwargs}')
-
-        _valid_read_args = {}
-        allowed_args = getfullargspec(self._read).args \
-            + getfullargspec(self._read).kwonlyargs
-        for k, v in _read_kwargs.items():
-            if k in allowed_args:
-                _valid_read_args[k] = v
-            else:
-                self.logger.warning(f'Ignoring invalid arg to _read: {k}')
-
-        data = [{'name': self.__name__,
-                 'data': self._read(**_valid_read_args),
-                 'type': type_,
-                 'schema': schema,
-                 'encoding': encoding}]
-
-        self.logger.info(f'Finished "read" in {time()-t0:.3f} seconds\n')
-        return data
-
-    def _read(self, filename):
+    def read(self, filename):
         """Read and return the data from requested from `filename`
 
         :param filename: Name of file to read from

--- a/CHAP/tomo/processor.py
+++ b/CHAP/tomo/processor.py
@@ -45,7 +45,7 @@ class TomoDataProcessor(Processor):
     step.
     """
 
-    def _process(
+    def process(
             self, data, interactive=False, reduce_data=False,
             find_center=False, reconstruct_data=False, combine_data=False,
             output_folder='.', save_figs=None, **kwargs):

--- a/CHAP/writer.py
+++ b/CHAP/writer.py
@@ -12,44 +12,15 @@ import logging
 from sys import modules
 from time import time
 
+# local modules
+from CHAP.pipeline import PipelineItem
 
-class Writer():
+
+class Writer(PipelineItem):
     """Writer represent generic file writer"""
 
-    def __init__(self):
-        """Constructor of Writer class"""
-        self.__name__ = self.__class__.__name__
-        self.logger = logging.getLogger(self.__name__)
-        self.logger.propagate = False
-
-    def write(self, data, filename, **_write_kwargs):
-        """write API
-
-        :param filename: Name of file to write to
-        :param data: data to write to file
-        :return: data written to file
-        """
-
-        t0 = time()
-        self.logger.info(f'Executing "write" with filename={filename}, '
-                         f'type(data)={type(data)}, kwargs={_write_kwargs}')
-
-        _valid_write_args = {}
-        allowed_args = getfullargspec(self._write).args \
-            + getfullargspec(self._write).kwonlyargs
-        for k, v in _write_kwargs.items():
-            if k in allowed_args:
-                _valid_write_args[k] = v
-            else:
-                self.logger.warning(f'Ignoring invalid arg to _write: {k}')
-
-        data = self._write(data, filename, **_valid_write_args)
-
-        self.logger.info(f'Finished "write" in {time()-t0:.3f} seconds\n')
-
-        return data
-
-    def _write(self, data, filename):
+    def write(self, data, filename):
+        data = self.unwrap_pipelinedata(data)
         with open(filename, 'a') as file:
             file.write(data)
         return data

--- a/examples/edd/pipeline.yaml
+++ b/examples/edd/pipeline.yaml
@@ -5,7 +5,6 @@ pipeline:
       url: https://gitlab01.classe.cornell.edu/api/v4/projects/308/repository/files/edd%2fdata.tar/raw?ref=main
       headers:
         PRIVATE-TOKEN: # your token here
-  - common.URLResponseProcessor
   - common.ExtractArchiveWriter:
       filename: examples/edd
 
@@ -19,12 +18,12 @@ pipeline:
       force_overwrite: true
 
   # Gather calibrated detector data
-  - common.MultipleReader:
-      readers:
-        - YAMLReader:
+  - pipeline.MultiplePipelineItem:
+      items:
+        - common.YAMLReader:
             filename: examples/edd/map.yaml
             schema: MapConfig
-        - YAMLReader:
+        - common.YAMLReader:
             filename: examples/edd/ceria_calibrated.yaml
             schema: MCACeriaCalibrationConfig
   - edd.MCADataProcessor
@@ -33,11 +32,11 @@ pipeline:
       force_overwrite: true
 
   # Compute sample strain map
-  - common.MultipleReader:
-      readers:
-        - NexusReader:
+  - pipeline.MultiplePipelineItem:
+      items:
+        - common.NexusReader:
             filename: examples/edd/map_detector_data.nxs
-        - YAMLReader:
+        - common.YAMLReader:
             filename: examples/edd/strain_analysis_config.yaml
             schema: StrainAnalysisConfig
   - common.StrainAnalysisProcessor

--- a/examples/saxswaxs/pipeline.yaml
+++ b/examples/saxswaxs/pipeline.yaml
@@ -5,7 +5,6 @@ pipeline:
       url: https://gitlab01.classe.cornell.edu/api/v4/projects/308/repository/files/saxswaxs%2fdata.tar/raw?ref=main
       headers:
         PRIVATE-TOKEN: # your token here
-  - common.URLResponseProcessor
   - common.ExtractArchiveWriter:
       filename: examples/saxswaxs
 
@@ -19,12 +18,12 @@ pipeline:
       force_overwrite: true
 
   # Integrate map detetcor data
-  - common.MultipleReader:
-      readers:
-        - YAMLReader:
+  - pipeline.MultiplePipelineItem:
+      items:
+        - common.YAMLReader:
             filename: examples/saxswaxs/map_1d.yaml
             schema: MapConfig
-        - YAMLReader:
+        - common.YAMLReader:
             filename: examples/saxswaxs/integration_saxs_azimuthal.yaml
             schema: IntegrationConfig
   - common.IntegrateMapProcessor

--- a/examples/sin2psi/pipeline.yaml
+++ b/examples/sin2psi/pipeline.yaml
@@ -6,7 +6,6 @@ pipeline:
 #      url: https://gitlab01.classe.cornell.edu/api/v4/projects/308/repository/files/sin2psi%2fdata.tar/raw?ref=main
 #      headers:
 #        PRIVATE-TOKEN: # your token here
-#  - common.URLResponseProcessor
 #  - common.ExtractArchiveWriter:
 #      filename: examples/sin2psi
 
@@ -20,12 +19,12 @@ pipeline:
       force_overwrite: true
 
   # Integrate map detector data
-  - common.MultipleReader:
-      readers:
-        - YAMLReader:
+  - pipeline.MultiplePipelineItem:
+      items:
+        - common.YAMLReader:
             filename: examples/sin2psi/map.yaml
             schema: MapConfig
-        - YAMLReader:
+        - common.YAMLReader:
             filename: examples/sin2psi/integration.yaml
             schema: IntegrationConfig
   - common.IntegrateMapProcessor
@@ -34,11 +33,11 @@ pipeline:
       force_overwrite: true
 
   # Compute sample strain map
-  - common.MultipleReader:
-      readers:
-        - NexusReader:
+  - pipeline.MultiplePipelineItem:
+      items:
+        - common.NexusReader:
             filename: examples/sin2psi/integrated_detector_data.nxs
-        - YAMLReader:
+        - common.YAMLReader:
             filename: examples/sin2psi/strain_analysis_config.yaml
             schema: StrainAnalysisConfig
   - common.StrainAnalysisProcessor


### PR DESCRIPTION
PipelineData is a dictionary that represents a standardized format for passing data between items in a Pipeline.

PipelineItem is an object from which Reader, Processor, and Writer all inherit.

Also implement MultiplePipelineItem. Replace all uses of MultipleReader in the example pipelines with MultiplePipelineItem.

cut: URLResponseProcessor.