### PR TITLE
Initial example of unit test

### DIFF
--- a/CHAP/test/common/reader_t.py
+++ b/CHAP/test/common/reader_t.py
@@ -1,0 +1,34 @@
+"""
+File       : common/reader.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: Unit tests for common/reader.py code
+"""
+
+# system modules
+import time
+import unittest
+
+# local modules
+from CHAP.common import YAMLReader
+
+
+class CommonReaderTest(unittest.TestCase):
+    """Unit test for common/reader.py module"""
+
+    def setUp(self):
+        self.fname = '/'.join(__file__.split("/")[:-2]) + '/data/file.yaml'
+        self.reader = YAMLReader()
+
+    def tierDown(self):
+        pass
+
+    def testReader(self):
+        """
+        Unit test to test reader
+        """
+        data = self.reader.read(self.fname)
+        self.assertEqual(isinstance(data, dict), True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/CHAP/test/data/file.yaml
+++ b/CHAP/test/data/file.yaml
@@ -1,0 +1,2 @@
+file: 1
+name: "bla"


### PR DESCRIPTION
This PR provides an example of unit test for CHAP component, in this case YAMLReader. I suggest to add appropriate unit tests for all other CHAP components and organize test area as following:
- test/common for unit tests of common module
- test/saxswaxs for unit tests related to saxswaxs
etc.

After we add unit test, I suggest to modify default CI/CD workflow to execute unit tests upon each commit or PR merge.

The unit test can be as following:
```
python test/common/reader_t.py
.
----------------------------------------------------------------------
Ran 1 test in 0.026s

OK
```
And, we should capture the status of this command, and if it fails we should break CI/CD and fail.