### PR TITLE
doc/build: add installation docs. add shebang to setup.py

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Update docs configuration with version (tag) name
       run: |
         sed -i "s/PACKAGE_VERSION/${{ github.ref_name }}/" docs/conf.py
+        sed -i "s/PACKAGE_VERSION/${{ github.ref_name }}/" docs/install.md
     - name: Build and deploy docs
       id: deployment
       uses: sphinx-notes/pages@v3

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 2
 :caption: Contents
+installation.md
 chap_cli.md
 apidocs/index.rst
 Galaxy.md

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,46 @@
+# Installation
+
+
+## Using `pip`
+CHAP is available over PyPI. Run
+```
+pip install ChessAnalysisPipeline
+```
+to install.
+
+## Using `conda`
+CHAP is available over conda-forge. Run
+```
+conda install chessanalysispipeline
+```
+to install.
+
+## From source
+1. Clone the CHAP repository.
+   ```{bash}
+   git clone https://github.com/CHESSComputing/ChessAnalysisPipeline.git
+   cd ChessAnalysisPipeline
+   ```
+1. Set a valid version number. In `setup.py`, replace:
+   ```{literalinclude} /../setup.py
+   :start-after: [set version]
+   :end-before: [version set]
+   ```
+   with
+   ```
+   version = 'PACKAGE_VERSION'
+   ```
+1. Setup a local installation prefix for your version of python
+   ```{bash}
+   mkdir -p install/lib/python<yourpythonversion>/site-packages
+   export PYTHONPATH=$PWD/install/lib/python<yourpythonversion>/site-packages
+   ```
+1. Use the setup script to install the package
+   ```
+   python setup.py install --prefix=$PWD/install
+   ```
+1. Try running
+   ```
+   install/bin/CHAP --help
+   ```
+   to confirm the package was installed correctly.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Standard python setup.py file
 to build     : python setup.py build
@@ -10,7 +11,9 @@ to run tests : python setup.py test
 import os
 import setuptools
 
+# [set version]
 version = 'PACKAGE_VERSION'
+# [version set]
 
 def datafiles(idir, pattern=None):
     """Return list of data files in provided relative dir"""


### PR DESCRIPTION
setup.py needs a shebang of its own in order for the CHAP executable to get the correct one when running setup.py install.