### PR TITLE
refactor: add a PipelineItem.get_config method

### DIFF
--- a/CHAP/common/processor.py
+++ b/CHAP/common/processor.py
@@ -108,56 +108,13 @@ class IntegrateMapProcessor(Processor):
         :rtype: nexusformat.nexus.NXprocess
         """
 
-        map_config, integration_config = self.get_configs(data)
+        map_config = self.get_config(
+            data, 'common.models.map.MapConfig')
+        integration_config = self.get_config(
+            data, 'common.models.integration.IntegrationConfig')
         nxprocess = self.get_nxprocess(map_config, integration_config)
 
         return nxprocess
-
-    def get_configs(self, data):
-        """Return valid instances of `MapConfig` and
-        `IntegrationConfig` from the input supplied by
-        `MultipleReader`.
-
-        :param data: Result of `Reader.read` where at least one item
-            has the value `'MapConfig'` for the `'schema'` key, and at
-            least one item has the value `'IntegrationConfig'` for the
-            `'schema'` key.
-        :type data: list[dict[str,object]]
-        :raises ValueError: if `data` cannot be parsed into map and
-            integration configurations.
-        :return: valid map and integration configuration objects.
-        :rtype: tuple[MapConfig, IntegrationConfig]
-        """
-
-        self.logger.debug('Getting configuration objects')
-        t0 = time()
-
-        from CHAP.common.models.map import MapConfig
-        from CHAP.common.models.integration import IntegrationConfig
-
-        map_config = False
-        integration_config = False
-        if isinstance(data, list):
-            for item in data:
-                if isinstance(item, dict):
-                    schema = item.get('schema')
-                    if schema == 'MapConfig':
-                        map_config = item.get('data')
-                    elif schema == 'IntegrationConfig':
-                        integration_config = item.get('data')
-
-        if not map_config:
-            raise ValueError('No map configuration found')
-        if not integration_config:
-            raise ValueError('No integration configuration found')
-
-        map_config = MapConfig(**map_config)
-        integration_config = IntegrationConfig(**integration_config)
-
-        self.logger.debug(
-            f'Got configuration objects in {time()-t0:.3f} seconds')
-
-        return map_config, integration_config
 
     def get_nxprocess(self, map_config, integration_config):
         """Use a `MapConfig` and `IntegrationConfig` to construct a
@@ -320,39 +277,10 @@ class MapProcessor(Processor):
         :rtype: nexusformat.nexus.NXentry
         """
 
-        map_config = self.get_map_config(data)
+        map_config = self.get_config(data, 'common.models.map.MapConfig')
         nxentry = self.__class__.get_nxentry(map_config)
 
         return nxentry
-
-    def get_map_config(self, data):
-        """Get an instance of `MapConfig` from a returned value of
-        `Reader.read`
-
-        :param data: Result of `Reader.read` where at least one item
-            has the value `'MapConfig'` for the `'schema'` key.
-        :type data: list[dict[str,object]]
-        :raises Exception: If a valid `MapConfig` cannot be
-            constructed from `data`.
-        :return: a valid instance of `MapConfig` with field values
-            taken from `data`.
-        :rtype: MapConfig
-        """
-
-        from CHAP.common.models.map import MapConfig
-
-        map_config = False
-        if isinstance(data, list):
-            for item in data:
-                if isinstance(item, dict):
-                    if item.get('schema') == 'MapConfig':
-                        map_config = item.get('data')
-                        break
-
-        if not map_config:
-            raise ValueError('No map configuration found')
-
-        return MapConfig(**map_config)
 
     @staticmethod
     def get_nxentry(map_config):

--- a/CHAP/test/common/processor_t.py
+++ b/CHAP/test/common/processor_t.py
@@ -116,7 +116,7 @@ class MapProcessorTest(unittest.TestCase):
             specf.write('\n'.join(spec_lines))
 
         self.processor = MapProcessor()
-        self.data = [PipelineData(schema='MapConfig',
+        self.data = [PipelineData(schema='common.models.map.MapConfig',
                                   data=map_config)]
 
     def testProcessor(self):
@@ -170,8 +170,9 @@ class IntegrateMapProcessorTest(MapProcessorTest):
                               'radial_min': 0.0,
                               'radial_max': 0.6}
         self.processor = IntegrateMapProcessor()
-        self.data += [PipelineData(schema='IntegrationConfig',
-                                   data=integration_config)]
+        self.data += [PipelineData(
+            schema='common.models.integration.IntegrationConfig',
+            data=integration_config)]
 
     def testProcessor(self):
         from nexusformat.nexus import NXprocess

--- a/examples/edd/pipeline.yaml
+++ b/examples/edd/pipeline.yaml
@@ -11,7 +11,7 @@ pipeline:
   # Calibrate detector
   - common.YAMLReader:
       filename: examples/edd/ceria_calibration_config.yaml
-      schema: MCACeriaCalibrationConfig
+      schema: edd.models.MCACeriaCalibrationConfig
   - edd.MCACeriaCalibrationProcessor
   - common.YAMLWriter:
       filename: examples/edd/ceria_calibrated.yaml
@@ -20,7 +20,7 @@ pipeline:
   # Measure diffraction volume length
   - common.YAMLReader:
       filename: examples/edd/dvl_measurement.yaml
-      schema: DiffractionVolumeLengthConfig
+      schema: edd.models.DiffractionVolumeLengthConfig
   - edd.DiffractionVolumeLengthProcessor:
       dvl_model: manual
   - common.YAMLWriter:
@@ -32,10 +32,10 @@ pipeline:
       items:
         - common.YAMLReader:
             filename: examples/edd/map.yaml
-            schema: MapConfig
+            schema: common.models.map.MapConfig
         - common.YAMLReader:
             filename: examples/edd/ceria_calibrated.yaml
-            schema: MCACeriaCalibrationConfig
+            schema: edd.models.MCACeriaCalibrationConfig
   - edd.MCADataProcessor
   - common.NexusWriter:
       filename: examples/edd/map_detector_data.nxs

--- a/examples/saxswaxs/pipeline.yaml
+++ b/examples/saxswaxs/pipeline.yaml
@@ -11,7 +11,7 @@ pipeline:
   # Collect map data
   - common.YAMLReader:
       filename: examples/saxswaxs/map_1d.yaml
-      schema: MapConfig
+      schema: common.models.map.MapConfig
   - common.MapProcessor
   - common.NexusWriter:
       filename: examples/saxswaxs/saxswaxs_map.nxs
@@ -22,10 +22,10 @@ pipeline:
       items:
         - common.YAMLReader:
             filename: examples/saxswaxs/map_1d.yaml
-            schema: MapConfig
+            schema: common.models.map.MapConfig
         - common.YAMLReader:
             filename: examples/saxswaxs/integration_saxs_azimuthal.yaml
-            schema: IntegrationConfig
+            schema: common.models.integration.IntegrationConfig
   - common.IntegrateMapProcessor
   - common.NexusWriter:
       filename: examples/saxswaxs/saxs_azimuthal_integrated.nxs

--- a/examples/sin2psi/pipeline.yaml
+++ b/examples/sin2psi/pipeline.yaml
@@ -12,7 +12,7 @@ pipeline:
   # Collect map data
   - common.YAMLReader:
       filename: examples/sin2psi/map.yaml
-      schema: MapConfig
+      schema: common.models.map.MapConfig
   - common.MapProcessor
   - common.NexusWriter:
       filename: examples/sin2psi/map.nxs
@@ -23,10 +23,10 @@ pipeline:
       items:
         - common.YAMLReader:
             filename: examples/sin2psi/map.yaml
-            schema: MapConfig
+            schema: common.models.map.MapConfig
         - common.YAMLReader:
             filename: examples/sin2psi/integration.yaml
-            schema: IntegrationConfig
+            schema: common.models.integration.IntegrationConfig
   - common.IntegrateMapProcessor
   - common.NexusWriter:
       filename: examples/sin2psi/integrated_detector_data.nxs


### PR DESCRIPTION
@rolfverberg -- items in CHAP.tomo have not yet been modified to use this method, since I noticed that the get_config(s) methods on tomo-related processors were a bit more complex compared to other processors. Do you want to modify them, or leave them as-is?

resolves #33 