### PR TITLE
fix: remove 'v' from the version attribute for galaxy tools' chap req…

### DIFF
--- a/.github/workflows/galaxy-tools.yml
+++ b/.github/workflows/galaxy-tools.yml
@@ -19,7 +19,7 @@ jobs:
         pip install planemo
     - name: Update tool version macro with CHAP version (tag) name
       run: |
-        sed -i "s/PACKAGE_VERSION/${{ github.ref_name }}/" galaxy-tools/macros.xml
+        sed -i "s/PACKAGE_VERSION/$(echo ${{ github.ref_name }} | sed s/v//)/" galaxy-tools/macros.xml
     - name: Update toolshed
       run: |
         planemo shed_update --shed_target testtoolshed --shed_key ${{secrets.XIMGCHESS_TESTTOOLSHED_KEY}}$ galaxy-tools


### PR DESCRIPTION
…uirement.

If the galaxy tools' CHAP requirement is this:
```
<requirement type="package" version="v0.0.10">chessanalysispipeline</requirement>
```
as opposed to 
```
<requirement type="package" version="0.0.10">chessanalysispipeline</requirement>
```
then the galaxy tools can be installed on galaxy-dev, but running any of the tools results in the following error:
```
galaxy.tool_util.deps.resolvers.DependencyException: Conda dependency seemingly installed but failed to build job environment.
```