### PR TITLE
feat: move run options from CLI to config file

### DIFF
--- a/CHAP/pipeline.py
+++ b/CHAP/pipeline.py
@@ -10,6 +10,7 @@ Description:
 # system modules
 import inspect
 import logging
+import os
 from time import time
 
 
@@ -141,10 +142,19 @@ class PipelineItem():
 
         if hasattr(self, 'read'):
             method_name = 'read'
+            inputdir = kwargs.get('inputdir')
+            if inputdir is not None:
+                kwargs['filename'] = os.path.join(inputdir,
+                                                  kwargs['filename'])
         elif hasattr(self, 'process'):
             method_name = 'process'
         elif hasattr(self, 'write'):
             method_name = 'write'
+            outputdir = kwargs.get('outputdir')
+            if outputdir is not None:
+                kwargs['filename'] = os.path.join(outputdir,
+                                                  kwargs['filename'])
+
         else:
             self.logger.error('No implementation of read, write, or process')
 


### PR DESCRIPTION
Make the config file the _only_ argument to the `CHAP` CLI. The config
file should now contain its own run options.

Add `root`, `input`, and `output` options:
- Default value for all is the current working directory.
- `input` and `output` may be relative or absolute. If relative, they
  are relative to `root`.
- `input`/`output` is prepended to the `filename` argument when
  executing `Reader.read`/`Writer.write`.

Closes #63