### PR TITLE
fix: don't append data with write in MultiplePipelineItem.execute

### DIFF
--- a/CHAP/common/processor.py
+++ b/CHAP/common/processor.py
@@ -368,7 +368,7 @@ class NexusToNumpyProcessor(Processor):
 
         from nexusformat.nexus import NXdata
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         if isinstance(data, NXdata):
             default_data = data
@@ -411,7 +411,7 @@ class NexusToXarrayProcessor(Processor):
         from nexusformat.nexus import NXdata
         from xarray import DataArray
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         if isinstance(data, NXdata):
             default_data = data
@@ -668,7 +668,7 @@ class XarrayToNexusProcessor(Processor):
 
         from nexusformat.nexus import NXdata, NXfield
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         signal = NXfield(value=data.data, name=data.name, attrs=data.attrs)
 
@@ -695,7 +695,7 @@ class XarrayToNumpyProcessor(Processor):
         :rtype: numpy.ndarray
         """
 
-        return self.unwrap_pipelinedata(data).data
+        return self.unwrap_pipelinedata(data).data[-1]
 
 
 if __name__ == '__main__':

--- a/CHAP/common/writer.py
+++ b/CHAP/common/writer.py
@@ -25,11 +25,11 @@ class ExtractArchiveWriter(Writer):
         :return: the original `data`
         :rtype: bytes
         """
-
+        # System modules
         from io import BytesIO
         import tarfile
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         with tarfile.open(fileobj=BytesIO(data)) as tar:
             tar.extractall(path=filename)
@@ -53,13 +53,14 @@ class MatplotlibFigureWriter(Writer):
             overwritten, if it already exists.
         :return: the original input data
         """
+        # Third party modules
+        from matplotlib.figure import Figure
 
         if os.path.isfile(filename) and not force_overwrite:
             raise FileExistsError(f'{filename} already exists')
 
-        figure = self.unwrap_pipelinedata(data)
+        figure = self.unwrap_pipelinedata(data)[-1]
 
-        from matplotlib.figure import Figure
         if not isinstance(figure, Figure):
             raise TypeError('Cannot write object of type'
                             f'{type(figure)} as a matplotlib Figure.')
@@ -80,14 +81,14 @@ class NexusWriter(Writer):
             overwritten, if it already exists.
         :return: the original input data
         """
-
+        # Third party modules
         from nexusformat.nexus import NXobject
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         if not isinstance(data, NXobject):
-            raise TypeError('Cannot write object of type '
-                            f'{type(data).__name__} to a NeXus file.')
+            raise TypeError('Cannot write object of type'
+                            f'{type(data).__name__} as a NeXus file.')
 
         mode = 'w' if force_overwrite else 'w-'
         data.save(filename, mode=mode)
@@ -113,10 +114,10 @@ class YAMLWriter(Writer):
         :return: the original input data
         :rtype: dict
         """
-
+        # Third party modules
         import yaml
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         if not isinstance(data, (dict, list)):
             raise TypeError(
@@ -157,7 +158,7 @@ class TXTWriter(Writer):
         # Local modules
         from CHAP.utils.general import is_str_series
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
 
         if not isinstance(data, str) and not is_str_series(data, log=False):
             raise TypeError(

--- a/CHAP/tomo/processor.py
+++ b/CHAP/tomo/processor.py
@@ -2829,7 +2829,7 @@ class TomoDarkFieldProcessor(Processor):
         )
 
         # Get and validate the TomoSimField configuration object in data
-        nxroot = get_nxroot(data, 'tomo.models.TomoSimField')
+        nxroot = get_nxroot(data, 'tomo.models.TomoSimField', remove=False)
         if nxroot is None:
             raise ValueError('No valid TomoSimField configuration found in '
                              'input data')
@@ -2901,7 +2901,7 @@ class TomoBrightFieldProcessor(Processor):
         )
 
         # Get and validate the TomoSimField configuration object in data
-        nxroot = get_nxroot(data, 'tomo.models.TomoSimField')
+        nxroot = get_nxroot(data, 'tomo.models.TomoSimField', remove=False)
         if nxroot is None:
             raise ValueError('No valid TomoSimField configuration found in '
                              'input data')

--- a/CHAP/writer.py
+++ b/CHAP/writer.py
@@ -38,7 +38,7 @@ class Writer(PipelineItem):
         :rtype: object
         """
 
-        data = self.unwrap_pipelinedata(data)
+        data = self.unwrap_pipelinedata(data)[-1]
         with open(filename, 'a') as file:
             file.write(data)
         return data

--- a/examples/tomo/pipeline_id3a.yaml
+++ b/examples/tomo/pipeline_id3a.yaml
@@ -3,50 +3,35 @@ config:
 
 pipeline:
 
-  # Create a simulated stack of tomography images
-  - common.YAMLReader:
-      filename: ../tomo_sim_id3a.yaml
-      schema: tomo.models.TomoSimConfig
-  - tomo.TomoSimFieldProcessor
-  - common.NexusWriter:
-      filename: hollow_brick_SIM_001.h5
-      force_overwrite: true
-
-  # Create the dark field for the simulation
-  - common.NexusReader:
-      filename: hollow_brick_SIM_001.h5
-      schema: tomo.models.TomoSimField
-  - tomo.TomoDarkFieldProcessor
-  - common.NexusWriter:
-      filename: hollow_brick_dark_SIM_001.h5
-      force_overwrite: true
-
-  # Create the bright field for the simulation
-  - common.NexusReader:
-      filename: hollow_brick_SIM_001.h5
-      schema: tomo.models.TomoSimField
-  - tomo.TomoBrightFieldProcessor:
-      num_image: 10
-  - common.NexusWriter:
-      filename: hollow_brick_flat_SIM_001.h5
-      force_overwrite: true
-
-  # Create the SPEC file for the simulation
   - pipeline.MultiplePipelineItem:
       items:
-        - common.NexusReader:
-            filename: hollow_brick_dark_SIM_001.h5
-            schema: tomo.models.TomoDarkField
-        - common.NexusReader:
-            filename: hollow_brick_flat_SIM_001.h5
-            schema: tomo.models.TomoBrightField
-        - common.NexusReader:
-            filename: hollow_brick_SIM_001.h5
+        # Create a simulated stack of tomography images
+        - common.YAMLReader:
+            filename: ../tomo_sim_id3a.yaml
+            schema: tomo.models.TomoSimConfig
+        - tomo.TomoSimFieldProcessor:
             schema: tomo.models.TomoSimField
-  - tomo.TomoSpecProcessor:
-      spec_folder: examples/tomo/hollow_brick
-      scan_numbers: [1, 2, 3, 4, 5]
-      force_overwrite: true
+        - common.NexusWriter:
+            filename: hollow_brick_SIM_001.h5
+            force_overwrite: true
+        # Create the dark field for the simulation
+        - tomo.TomoDarkFieldProcessor:
+            schema: tomo.models.TomoDarkField
+        - common.NexusWriter:
+            filename: hollow_brick_dark_SIM_001.h5
+            force_overwrite: true
+        # Create the bright field for the simulation
+        - tomo.TomoBrightFieldProcessor:
+            schema: tomo.models.TomoBrightField
+            num_image: 10
+        - common.NexusWriter:
+            filename: hollow_brick_flat_SIM_001.h5
+            force_overwrite: true
+        # Create the SPEC file for the simulation
+        - tomo.TomoSpecProcessor:
+            spec_folder: examples/tomo/hollow_brick
+            scan_numbers: [1, 2, 3, 4, 5]
+            force_overwrite: true
 
   # Convert the CHESS style map
   - pipeline.MultiplePipelineItem:

--- a/examples/tomo/pipeline_id3b.yaml
+++ b/examples/tomo/pipeline_id3b.yaml
@@ -3,51 +3,36 @@ config:
 
 pipeline:
 
-  # Create a simulated stack of tomography images
-  - common.YAMLReader:
-      filename: ../tomo_sim_id3b.yaml
-      schema: tomo.models.TomoSimConfig
-  - tomo.TomoSimFieldProcessor
-  - common.NexusWriter:
-      filename: hollow_cube_SIM_003.h5
-      force_overwrite: true
-
-  # Create the dark field for the simulation
-  - common.NexusReader:
-      filename: hollow_cube_SIM_003.h5
-      schema: tomo.models.TomoSimField
-  - tomo.TomoDarkFieldProcessor
-  - common.NexusWriter:
-      filename: hollow_cube_SIM_001.h5
-      force_overwrite: true
-
-  # Create the bright field for the simulation
-  - common.NexusReader:
-      filename: hollow_cube_SIM_003.h5
-      schema: tomo.models.TomoSimField
-  - tomo.TomoBrightFieldProcessor:
-      num_image: 10
-  - common.NexusWriter:
-      filename: hollow_cube_SIM_002.h5
-      force_overwrite: true
-
-  # Create the SPEC file for the simulation
   - pipeline.MultiplePipelineItem:
       items:
-        - common.NexusReader:
-            filename: hollow_cube_SIM_001.h5
-            schema: tomo.models.TomoDarkField
-        - common.NexusReader:
-            filename: hollow_cube_SIM_002.h5
-            schema: tomo.models.TomoBrightField
-        - common.NexusReader:
-            filename: hollow_cube_SIM_003.h5
+        # Create a simulated stack of tomography images
+        - common.YAMLReader:
+            filename: ../tomo_sim_id3b.yaml
+            schema: tomo.models.TomoSimConfig
+        - tomo.TomoSimFieldProcessor:
             schema: tomo.models.TomoSimField
-  - tomo.TomoSpecProcessor:
-      scan_numbers: [1, 2, 3]
-  - common.TXTWriter:
-      filename: hollow_cube
-      force_overwrite: true
+        - common.NexusWriter:
+            filename: hollow_cube_SIM_003.h5
+            force_overwrite: true
+        # Create the dark field for the simulation
+        - tomo.TomoDarkFieldProcessor:
+            schema: tomo.models.TomoDarkField
+        - common.NexusWriter:
+            filename: hollow_cube_SIM_001.h5
+            force_overwrite: true
+        # Create the bright field for the simulation
+        - tomo.TomoBrightFieldProcessor:
+            schema: tomo.models.TomoBrightField
+            num_image: 10
+        - common.NexusWriter:
+            filename: hollow_cube_SIM_002.h5
+            force_overwrite: true
+        # Create the SPEC file for the simulation
+        - tomo.TomoSpecProcessor:
+            scan_numbers: [1, 2, 3]
+        - common.TXTWriter:
+            filename: hollow_cube
+            force_overwrite: true
 
   # Convert the CHESS style map
   - pipeline.MultiplePipelineItem:


### PR DESCRIPTION
Also:
Modified PipelineItem.unwrap_pipelinedata to always return a list
   and the write routines to always write the last item in the list
Adjust tomo examples to use MultiplePipelineItem in simulator