### PR TITLE
First Pull Request! And: Ecal plot file name change

### DIFF
--- a/CHAP/edd/processor.py
+++ b/CHAP/edd/processor.py
@@ -1263,7 +1263,7 @@ class MCAEnergyCalibrationProcessor(Processor):
             fig.tight_layout()
 
             if save_figures:
-                figfile = os.path.join(outputdir, 'energy_calibration_fit.png')
+                figfile = os.path.join(outputdir, f'energy_calibration_fit_{detector.detector_name}.png')
                 plt.savefig(figfile)
                 self.logger.info(f'Saved figure to {figfile}')
             if interactive:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import os
 import setuptools
 
 # [set version]
-version = 'PACKAGE_VERSION'
+version = 'v0.0.14'
 # [version set]
 
 def datafiles(idir, pattern=None):


### PR DESCRIPTION
When performing E cal on multiple detectors, this version prevents output files from overwriting each other by appending the detector name to the output plot file.

(Unsure whether 2nd change -- VERSION number -- should be accepted).