### PR TITLE
fix: error in return ConstructBaseline.construct_baseline

### DIFF
--- a/CHAP/common/processor.py
+++ b/CHAP/common/processor.py
@@ -737,7 +737,10 @@ class ConstructBaseline(Processor):
             full_output=True)
 
         if not interactive and filename is None:
-            return baseline
+            config = {
+                'tol': tol, 'lambda': lam, 'max_iter': max_iter,
+                'num_iter': num_iter, 'error': error, 'mask': mask}
+            return baseline, config
 
         lambdas = [lam]
         weights = [w]


### PR DESCRIPTION
Missing config when running non-interactively