### PR TITLE
fix: Make strain analysis and fit processor robust for zero data

### DIFF
--- a/CHAP/edd/models.py
+++ b/CHAP/edd/models.py
@@ -451,7 +451,7 @@ class MCAElementStrainAnalysisConfig(MCAElementConfig):
     hkl_indices: Optional[conlist(item_type=conint(ge=0))] = []
     background: Optional[Union[str, list]] = None
     baseline: Optional[Union[bool, BaselineConfig]] = False
-    num_proc: Optional[conint(gt=0)] = os.cpu_count()
+    num_proc: Optional[conint(gt=0)] = max(1, os.cpu_count()//4)
     peak_models: Union[
         conlist(min_length=1, item_type=Literal['gaussian', 'lorentzian']),
         Literal['gaussian', 'lorentzian']] = 'gaussian'


### PR DESCRIPTION
Also:
- Set default of allow_approximate_coordinates in UpdateNXdataProcessor to False, which makes more sense for unstructured grids
- Add inputdir to UpdateNXdataProcessor for nxfilename
- Cap the number of processors in fit to a quarter of the maximum available.
- Skip strain analysis for detectors for which all data is zero.