### PR TITLE
FOXDEN integration with CHAP

### DIFF
--- a/CHAP/foxden/__init__.py
+++ b/CHAP/foxden/__init__.py
@@ -1,6 +1,7 @@
 """This subpackage contains pieces for communication with FOXDEN services.
 """
 
-from CHAP.foxden.processor import FoxdenProvenanceProcessor
-# from CHAP.foxden.reader import
+from CHAP.foxden.processor import FoxdenProvenanceProcessor, \
+    FoxdenMetaDataProcessor
+from CHAP.foxden.reader import FoxdenReader
 from CHAP.foxden.writer import FoxdenWriter

--- a/CHAP/foxden/__init__.py
+++ b/CHAP/foxden/__init__.py
@@ -1,7 +1,6 @@
 """This subpackage contains pieces for communication with FOXDEN services.
 """
 
-from CHAP.foxden.processor import FoxdenProvenanceProcessor, \
-    FoxdenMetaDataProcessor
+from CHAP.foxden.processor import FoxdenProvenanceProcessor, FoxdenMetaDataProcessor
 from CHAP.foxden.reader import FoxdenReader
 from CHAP.foxden.writer import FoxdenWriter

--- a/CHAP/foxden/processor.py
+++ b/CHAP/foxden/processor.py
@@ -12,25 +12,62 @@ from time import time
 
 # Local modules
 from CHAP.processor import Processor
+from CHAP.foxden.writer import FoxdenWriter
+
+class FoxdenMetaDataProcessor(Processor):
+    """A Processor to communicate with FOXDEN MetaData server."""
+
+    def process(self, data, url, did, dryRun=False, verbose=False):
+        """FOXDEN MetaData processor
+
+        :param data: Input data.
+        :type data: list[PipelineData]
+        :param url: URL of service.
+        :type url: str
+        :param did: FOXDEN dataset identifier (did)
+        :type did: string
+        :param dryRun: `dryRun` option to verify HTTP workflow,
+            defaults to `False`.
+        :type dryRun: bool, optional
+        :param verbose: verbose output
+        :type verbose: bool, optional
+        :return: data from FOXDEN MetaData service
+        """
+        t0 = time()
+        self.logger.info(
+            f'Executing "process" with url={url} data={data} did={did}')
+#         reader = FoxdenReader()
+#         data = reader.read(data, url, dryRun=dryRun)
+        self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
+
+        return data
 
 class FoxdenProvenanceProcessor(Processor):
     """A Processor to communicate with FOXDEN provenance server."""
 #    def __init__(self):
 #        self.writer = FoxdenWriter()
 
-    def process(self, data, url, dryRun=False, verbose=False):
-        """Process the data API."""
-        # Local modules
-        from CHAP.foxden.writer import FoxdenWriter
+    def process(self, data, url, did, dryRun=False, verbose=False):
+        """FOXDEN Provenance processor
 
+        :param data: Input data.
+        :type data: list[PipelineData]
+        :param url: URL of service.
+        :type url: str
+        :param did: FOXDEN dataset identifier (did)
+        :type did: string
+        :param dryRun: `dryRun` option to verify HTTP workflow,
+            defaults to `False`.
+        :type dryRun: bool, optional
+        :param verbose: verbose output
+        :type verbose: bool, optional
+        :return: data from FOXDEN provenance service
+        """
         t0 = time()
         self.logger.info(
-            f'Executing "process" with url {url} data {data} dryrun {dryRun}')
-        writer = FoxdenWriter()
-
-#        data = self.writer.write(data, url, dryRun)
-        data = writer.write(data, url, dryRun=dryRun)
-
+            f'Executing "process" with url={url} data={data} did={did}')
+#         writer = FoxdenWriter()
+#         data = writer.write(data, url, dryRun=dryRun)
         self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
 
         return data

--- a/CHAP/foxden/processor.py
+++ b/CHAP/foxden/processor.py
@@ -13,6 +13,7 @@ from time import time
 # Local modules
 from CHAP.processor import Processor
 from CHAP.foxden.writer import FoxdenWriter
+from CHAP.foxden.utils import HttpRequest
 
 class FoxdenMetaDataProcessor(Processor):
     """A Processor to communicate with FOXDEN MetaData server."""
@@ -36,8 +37,10 @@ class FoxdenMetaDataProcessor(Processor):
         t0 = time()
         self.logger.info(
             f'Executing "process" with url={url} data={data} did={did}')
-#         reader = FoxdenReader()
-#         data = reader.read(data, url, dryRun=dryRun)
+        rurl = f'{url}/search'
+        payload = {"did": did}
+        response = HttpRequest(data, url, method='POST')
+        print("http response", rurl, payload, response)
         self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
 
         return data

--- a/CHAP/foxden/reader.py
+++ b/CHAP/foxden/reader.py
@@ -1,5 +1,36 @@
-#!/usr/bin/env python
-"""FOXDEN command line reader."""
+"""FOXDEN reader."""
+
+from CHAP.foxden.utils import HttpRequest
+
+
+class FoxdenReader():
+    """FOXDEN reader reads data from specific FOXDEN service."""
+    def read(
+            self, data, url, method='GET', headers=None, timeout=10,
+            dryRun=False):
+        """Read data from FOXDEN service
+
+        :param data: Input data.
+        :type data: list[PipelineData]
+        :param url: URL of service.
+        :type url: str
+        :param method: HTTP method to use, `"POST"` for creation and
+            `"PUT"` for update, defaults to `"POST"`.
+        :type method: str, optional
+        :param headers: HTTP headers to use.
+        :type headers: dictionary, optional
+        :param tokenEnv: environment token variable
+        :type tokenEnv: string
+        :param timeout: Timeout of HTTP request, defaults to `10`.
+        :type timeout: str, optional
+        :param dryRun: `dryRun` option to verify HTTP workflow,
+            defaults to `False`.
+        :type dryRun: bool, optional
+        :return: Contents of the input data.
+        :rtype: object
+        """
+        return HttpRequest(data, url, method, headers, 'CHESS_READER_TOKEN', timeout, dryrun)
+
 
 if __name__ == '__main__':
     # Local modules

--- a/CHAP/foxden/reader.py
+++ b/CHAP/foxden/reader.py
@@ -6,8 +6,8 @@ from CHAP.foxden.utils import HttpRequest
 class FoxdenReader():
     """FOXDEN reader reads data from specific FOXDEN service."""
     def read(
-            self, data, url, method='GET', headers=None, timeout=10,
-            dryRun=False):
+            self, url, data, method='GET', headers=None,
+            scope='read', timeout=10, dryRun=False):
         """Read data from FOXDEN service
 
         :param data: Input data.
@@ -19,8 +19,8 @@ class FoxdenReader():
         :type method: str, optional
         :param headers: HTTP headers to use.
         :type headers: dictionary, optional
-        :param tokenEnv: environment token variable
-        :type tokenEnv: string
+        :param scope: FOXDEN scope to use, e.g. read or write
+        :type scope: string
         :param timeout: Timeout of HTTP request, defaults to `10`.
         :type timeout: str, optional
         :param dryRun: `dryRun` option to verify HTTP workflow,
@@ -29,7 +29,7 @@ class FoxdenReader():
         :return: Contents of the input data.
         :rtype: object
         """
-        return HttpRequest(data, url, method, headers, 'CHESS_READER_TOKEN', timeout, dryrun)
+        return HttpRequest(url, data, method, headers, scope, timeout, dryrun)
 
 
 if __name__ == '__main__':

--- a/CHAP/foxden/utils.py
+++ b/CHAP/foxden/utils.py
@@ -13,6 +13,7 @@ def readFoxdenToken(scope):
     token = ''
     rfile = os.path.join(os.getenv('HOME'), '.foxden.read.yaml')
     wfile = os.path.join(os.getenv('HOME'), '.foxden.write.yaml')
+    tfile = none
     if scope == 'read':
         if os.getenv('FOXDEN_READ_TOKEN'):
             token = os.getenv('FOXDEN_READ_TOKEN')

--- a/CHAP/foxden/utils.py
+++ b/CHAP/foxden/utils.py
@@ -11,20 +11,22 @@ def readFoxdenToken(scope):
     """
     """
     token = ''
-    rfile = os.path.join(os.getenv('HOME'), '.foxden.read.yaml')
-    wfile = os.path.join(os.getenv('HOME'), '.foxden.write.yaml')
+    rfile = os.path.join(os.getenv('HOME'), '.foxden.read.token')
+    wfile = os.path.join(os.getenv('HOME'), '.foxden.write.token')
     tfile = None
+    rtoken = os.getenv('FOXDEN_READ_TOKEN')
+    wtoken = os.getenv('FOXDEN_WRITE_TOKEN')
     if scope == 'read':
-        if os.getenv('FOXDEN_READ_TOKEN'):
-            token = os.getenv('FOXDEN_READ_TOKEN')
+        if rtoken != "":
+            token = rtoken
         elif os.path.exists(rfile):
             tfile = rfile
     elif scope == 'write':
-        if os.getenv('FOXDEN_WRITE_TOKEN'):
-            token = os.getenv('FOXDEN_WRITE_TOKEN')
-        elif os.path.exists(rfile):
+        if wtoken != "":
+            token = wtoken
+        elif os.path.exists(wfile):
             tfile = wfile
-    if not token and os.path.exists(tfile):
+    if not token and tfile and os.path.exists(tfile):
         with open(tfile, 'r') as istream:
             token = istream.read()
     return token

--- a/CHAP/foxden/utils.py
+++ b/CHAP/foxden/utils.py
@@ -13,7 +13,7 @@ def readFoxdenToken(scope):
     token = ''
     rfile = os.path.join(os.getenv('HOME'), '.foxden.read.yaml')
     wfile = os.path.join(os.getenv('HOME'), '.foxden.write.yaml')
-    tfile = none
+    tfile = None
     if scope == 'read':
         if os.getenv('FOXDEN_READ_TOKEN'):
             token = os.getenv('FOXDEN_READ_TOKEN')

--- a/CHAP/foxden/utils.py
+++ b/CHAP/foxden/utils.py
@@ -31,8 +31,7 @@ def readFoxdenToken(scope):
             token = istream.read()
     return token
 
-def HttpRequest(
-        data, url, method='GET', headers=None,
+def HttpRequest(url, data, method='GET', headers=None,
         scope='read', timeout=10, dryRun=False):
     """Read data from FOXDEN service
 
@@ -72,7 +71,7 @@ def HttpRequest(
         return []
 
     # Make actual HTTP request to FOXDEN service
-    if method.lower() == 'post':
+    if method.lower() == 'get':
         resp = requests.get(
             url, headers=headers, timeout=timeout)
     elif method.lower() == 'post':
@@ -86,5 +85,4 @@ def HttpRequest(
             url, headers=headers, timeout=timeout, data=data)
     else:
         raise Exception(f'unsupported method {method}')
-    data = resp.content
-    return data
+    return resp

--- a/CHAP/foxden/utils.py
+++ b/CHAP/foxden/utils.py
@@ -17,12 +17,12 @@ def readFoxdenToken(scope):
     rtoken = os.getenv('FOXDEN_READ_TOKEN')
     wtoken = os.getenv('FOXDEN_WRITE_TOKEN')
     if scope == 'read':
-        if rtoken != "":
+        if rtoken:
             token = rtoken
         elif os.path.exists(rfile):
             tfile = rfile
     elif scope == 'write':
-        if wtoken != "":
+        if wtoken:
             token = wtoken
         elif os.path.exists(wfile):
             tfile = wfile

--- a/CHAP/foxden/utils.py
+++ b/CHAP/foxden/utils.py
@@ -1,0 +1,71 @@
+"""FOXDEN utils module."""
+
+# system modules
+import os
+
+# 3rd party modules
+import requests
+
+
+def HttpRequest(
+        self, data, url, method='GET', headers=None,
+        tokenEnv='CHESS_READER_TOKEN', timeout=10, dryRun=False):
+    """Read data from FOXDEN service
+
+    :param data: Input data.
+    :type data: list[PipelineData]
+    :param url: URL of service.
+    :type url: str
+    :param method: HTTP method to use, `"POST"` for creation and
+        `"PUT"` for update, defaults to `"POST"`.
+    :type method: str, optional
+    :param headers: HTTP headers to use.
+    :type headers: dictionary, optional
+    :param tokenEnv: environment token variable
+    :type tokenEnv: string
+    :param timeout: Timeout of HTTP request, defaults to `10`.
+    :type timeout: str, optional
+    :param dryRun: `dryRun` option to verify HTTP workflow,
+        defaults to `False`.
+    :type dryRun: bool, optional
+    :return: Contents of the input data.
+    :rtype: object
+    """
+    if headers is None:
+        headers = {}
+    if 'Content-Type' not in headers:
+        headers['Content-type'] = 'application/json'
+    if 'Accept' not in headers:
+        headers['Accept'] = 'application/json'
+    if dryRun:
+        print('### HTTP reader call', url, headers, data)
+        return []
+    token = ''
+    fname = os.getenv(tokenEnv)
+    if not fname:
+        raise Exception(f'{tokenEnv} env variable is not set')
+    with open(fname, 'r') as istream:
+        token = istream.read()
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+    else:
+        raise Exception(
+                f'Valid write token missing in {tokenEnv} env variable')
+
+    # Make actual HTTP request to FOXDEN service
+    if method.lower() == 'post':
+        resp = requests.get(
+            url, headers=headers, timeout=timeout)
+    elif method.lower() == 'post':
+        resp = requests.post(
+            url, headers=headers, timeout=timeout, data=data)
+    elif method.lower() == 'put':
+        resp = requests.put(
+            url, headers=headers, timeout=timeout, data=data)
+    elif method.lower() == 'delete':
+        resp = requests.delete(
+            url, headers=headers, timeout=timeout, data=data)
+    else:
+        raise Exception(f'unsupported method {method}')
+    data = resp.content
+    return data

--- a/CHAP/foxden/writer.py
+++ b/CHAP/foxden/writer.py
@@ -1,11 +1,14 @@
-"""FOXDEN command line writer."""
+"""FOXDEN writer."""
+
+from CHAP.foxden.utils import HttpRequest
+
 
 class FoxdenWriter():
     """FOXDEN writer writes data to specific FOXDEN service."""
     def write(
-            self, data, url, method='POST', headers=None, timeout=10,
-            dryRun=False):
-        """Write the input data as text to a file.
+            self, data, url, method='POST', headers=None,
+            tokenEnv='CHESS_WRITER_TOKEN', timeout=10, dryRun=False):
+        """Write data to FOXDEN
 
         :param data: Input data.
         :type data: list[PipelineData]
@@ -15,6 +18,8 @@ class FoxdenWriter():
             `"PUT"` for update, defaults to `"POST"`.
         :type method: str, optional
         :param headers: HTTP headers to use.
+        :param tokenEnv: environment token variable
+        :type tokenEnv: string
         :type headers: dictionary, optional
         :param timeout: Timeout of HTTP request, defaults to `10`.
         :type timeout: str, optional
@@ -24,44 +29,7 @@ class FoxdenWriter():
         :return: Contents of the input data.
         :rtype: object
         """
-        # System modules
-        import os
-
-        # Third party modules
-        import requests
-
-        if headers is None:
-            headers = {}
-        if 'Content-Type' not in headers:
-            headers['Content-type'] = 'application/json'
-        if 'Accept' not in headers:
-            headers['Accept'] = 'application/json'
-        if dryRun:
-            print('### HTTP writer call', url, headers, data)
-            return []
-        token = ''
-        fname = os.getenv('CHESS_WRITE_TOKEN')
-        if not fname:
-            raise Exception('CHESS_WRITE_TOKEN env variable is not set')
-        with open(fname, 'r') as istream:
-            token = istream.read()
-        if token:
-            headers['Authorization'] = f'Bearer {token}'
-        else:
-            raise Exception(
-                'Valid write token missing in CHESS_WRITE_TOKEN env variable')
-
-        # Make actual HTTP request to FOXDEN service
-        if method.lower() == 'post':
-            resp = requests.post(
-                url, headers=headers, timeout=timeout, data=data)
-        elif method.lower() == 'put':
-            resp = requests.put(
-                url, headers=headers, timeout=timeout, data=data)
-        else:
-            raise Exception(f'unsupporteed method {method}')
-        data = resp.content
-        return data
+        return HttpRequest(data, url, method, headers, 'CHESS_READER_TOKEN', timeout, dryrun)
 
 
 if __name__ == '__main__':

--- a/CHAP/foxden/writer.py
+++ b/CHAP/foxden/writer.py
@@ -6,8 +6,8 @@ from CHAP.foxden.utils import HttpRequest
 class FoxdenWriter():
     """FOXDEN writer writes data to specific FOXDEN service."""
     def write(
-            self, data, url, method='POST', headers=None,
-            tokenEnv='CHESS_WRITER_TOKEN', timeout=10, dryRun=False):
+            self, url, data, method='POST', headers=None,
+            scope='write', timeout=10, dryRun=False):
         """Write data to FOXDEN
 
         :param data: Input data.
@@ -18,8 +18,8 @@ class FoxdenWriter():
             `"PUT"` for update, defaults to `"POST"`.
         :type method: str, optional
         :param headers: HTTP headers to use.
-        :param tokenEnv: environment token variable
-        :type tokenEnv: string
+        :param scope: FOXDEN scope to use, e.g. read or write
+        :type scope: string
         :type headers: dictionary, optional
         :param timeout: Timeout of HTTP request, defaults to `10`.
         :type timeout: str, optional
@@ -29,7 +29,7 @@ class FoxdenWriter():
         :return: Contents of the input data.
         :rtype: object
         """
-        return HttpRequest(data, url, method, headers, 'CHESS_READER_TOKEN', timeout, dryrun)
+        return HttpRequest(url, data, method, headers, scope, timeout, dryrun)
 
 
 if __name__ == '__main__':

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,3 +45,25 @@ to install.
    install/bin/CHAP --help
    ```
    to confirm the package was installed correctly.
+1. If you need to install it in your local installation area via pip please
+   follow the following steps:
+```
+# install wheel package
+pip install wheel
+
+# build your local package
+python setup.py clean sdist bdist_wheel
+
+# look-up your local package in dist area
+ls -1 dist
+ChessAnalysisPipeline-0.0.16-py3-none-any.whl
+ChessAnalysisPipeline-0.0.16-py3.11.egg
+ChessAnalysisPipeline-0.0.16.tar.gz
+
+# install your package from local dist area
+pip install --no-index --find-links=dist/ ChessAnalysisPipeline
+
+# verify that you package is installed
+pip list | grep Chess
+ChessAnalysisPipeline 0.0.16
+```

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##H reinstall CHAP into local venv area
+##H Usage: reinstall.sh
+##H
+# Check if user is passing least required arguments.
+if  [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
+    cat $0 | grep "^##H" | sed -e "s,##H,,g"
+    exit 1
+fi
+
+echo "# uninstall CHAP from pip..."
+pip uninstall --yes ChessAnalysisPipeline
+echo
+echo "# cleanup exists packages in dist..."
+rm dist/*
+echo
+echo "# build new package distribution..."
+python setup.py clean sdist bdist_wheel
+echo
+echo "# install CHAP from dist..."
+pip install --no-index --find-links=dist/ ChessAnalysisPipeline
+echo
+echo "# check if CHAP exists in pip..."
+pip list | grep Ches


### PR DESCRIPTION
FYI: @keara-soloway , @wernersun , @rolfverberg 

This PR contains initial integration of FOXDEN services with CHAP. In particular I provided implementation for FoxdenMetaDataProcessor and FoxdenProvenanceProcessor. The full workflow was tested with the following configuration using locally deployed FOXDEN services:
```
config:
  inputdir: .
  outputdir: output # Change as desired
  interactive: true # Change as desired
  log_level: INFO
  profile: false

pipeline:
  - foxden.FoxdenMetaDataProcessor:
      did: "/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child"
      url: "http://localhost:8300"
      dryRun: True
  - common.PrintProcessor: {}
  - foxden.FoxdenProvenanceProcessor:
      did: "/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child"
      url: "http://localhost:8310"
      dryRun: True
  - common.PrintProcessor: {}
```
The output of this pipeline workflow looks like this:
```
2025-03-14 11:46:29: CHAP.runner         : INFO: Input pipeline configuration: [{'foxden.FoxdenMetaDataProcessor': {'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'url': 'http://localhost:8300', 'dryRun': True}}, {'common.PrintProcessor': {}}, {'foxden.FoxdenProvenanceProcessor': {'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'url': 'http://localhost:8310', 'dryRun': True}}, {'common.PrintProcessor': {}}]

2025-03-14 11:46:30: CHAP.runner         : INFO: Loaded <CHAP.foxden.processor.FoxdenMetaDataProcessor object at 0x1026ff910>
2025-03-14 11:46:30: CHAP.runner         : INFO: Loaded <CHAP.common.processor.PrintProcessor object at 0x1026f77d0>
2025-03-14 11:46:30: CHAP.runner         : INFO: Loaded <CHAP.foxden.processor.FoxdenProvenanceProcessor object at 0x1026f4210>
2025-03-14 11:46:30: CHAP.runner         : INFO: Loaded <CHAP.common.processor.PrintProcessor object at 0x1026f7c50>
2025-03-14 11:46:30: CHAP.runner         : INFO: Loaded <CHAP.pipeline.Pipeline object at 0x115cee2d0> with 4 items

2025-03-14 11:46:30: CHAP.runner         : INFO: Calling "execute" on <CHAP.pipeline.Pipeline object at 0x115cee2d0>
2025-03-14 11:46:30: Pipeline            : INFO: Executing "execute"

2025-03-14 11:46:30: Pipeline            : INFO: Calling "execute" on <CHAP.foxden.processor.FoxdenMetaDataProcessor object at 0x1026ff910>
2025-03-14 11:46:30: FoxdenMetaDataProcessor: INFO: Executing "process"
2025-03-14 11:46:30: FoxdenMetaDataProcessor: INFO: Executing "process" with url=http://localhost:8300 data=[] did=/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child
2025-03-14 11:46:30: FoxdenMetaDataProcessor: INFO: Finished "process" in 0.015 seconds

2025-03-14 11:46:30: FoxdenMetaDataProcessor: INFO: Finished "process" in 0 seconds

2025-03-14 11:46:30: Pipeline            : INFO: Calling "execute" on <CHAP.common.processor.PrintProcessor object at 0x1026f77d0>
2025-03-14 11:46:30: PrintProcessor      : INFO: Executing "process"
2025-03-14 11:46:30: PrintProcessor      : INFO: Finished "process" in 0 seconds

2025-03-14 11:46:30: Pipeline            : INFO: Calling "execute" on <CHAP.foxden.processor.FoxdenProvenanceProcessor object at 0x1026f4210>
2025-03-14 11:46:30: FoxdenProvenanceProcessor: INFO: Executing "process"
2025-03-14 11:46:30: FoxdenProvenanceProcessor: INFO: Executing "process" with url=http://localhost:8310 data=[{'name': 'PrintProcessor', 'data': [{'name': 'FoxdenMetaDataProcessor', 'data': [{'_id': '679b74190750c4ed9d2c1918', 'affiliation': ['Industry'], 'alignment': False, 'beam_energy': 312.462, 'beamline': ['3A'], 'beamline_funding_partner': ['CHEXS_NSF'], 'beamline_setup_document': '/tmp', 'btr': 'test-987-b', 'calibration': False, 'calibration_document': '', 'cesr_conditions': ['9x5_bunch_mode'], 'cycle': '2024-1', 'data_location_beamtime_notes': '/tmp', 'data_location_meta': '/tmp', 'data_location_raw': '/tmp', 'data_location_reduced': '/tmp', 'data_location_scratch': '/tmp', 'date': 1730913016, 'detectors': ['other'], 'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'energy_foil': ['Sn'], 'energy_scan_document': 'null', 'experiment_type': ['other'], 'experimenters': 'FleischauerV, WolfordN, ChanB, TerjesenC, FisherY', 'facility': 'CHESS', 'focusing': ['None'], 'furnace': [''], 'in_situ': False, 'insertion_device': ['CCU'], 'material_safety_hazardous_samples': False, 'mechanical_grips': [''], 'mechanical_load_frame': ['RAMSII'], 'mechanical_test': False, 'mechanical_test_type': [''], 'monochromator': ['double_crystal_bragg_si220'], 'pi': 'wolford', 'processing_environment': [''], 'sample_chemical_formula': 'none', 'sample_common_name': 'none', 'sample_geometry': 'none', 'sample_mat_ped_heat_treatment': 'none', 'sample_mat_ped_processing_route': 'none', 'sample_name': 'lup-20kev-1', 'sample_state': [''], 'schema': 'ID3A', 'schema_file': '/Users/vk/Work/CHESS/FOXDEN/FOXDEN/configs/ID3A.json', 'staff_scientist': ['ShanksKS'], 'supplementary_technique': [''], 'technique': ['other'], 'undulator_scan_document': 'null'}], 'schema': None}], 'schema': None}] did=/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child
2025-03-14 11:46:30: FoxdenProvenanceProcessor: INFO: Finished "process" in 0 seconds

2025-03-14 11:46:30: Pipeline            : INFO: Calling "execute" on <CHAP.common.processor.PrintProcessor object at 0x1026f7c50>
2025-03-14 11:46:30: PrintProcessor      : INFO: Executing "process"
2025-03-14 11:46:30: PrintProcessor      : INFO: Finished "process" in 0 seconds

2025-03-14 11:46:30: Pipeline            : INFO: Executed "execute" in 0.020 seconds
2025-03-14 11:46:30: CHAP.runner         : INFO: Executed "run" in 0.076 seconds
responpse <Response [200]> <class 'requests.models.Response'>
record
 [{'_id': '679b74190750c4ed9d2c1918', 'affiliation': ['Industry'], 'alignment': False, 'beam_energy': 312.462, 'beamline': ['3A'], 'beamline_funding_partner': ['CHEXS_NSF'], 'beamline_setup_document': '/tmp', 'btr': 'test-987-b', 'calibration': False, 'calibration_document': '', 'cesr_conditions': ['9x5_bunch_mode'], 'cycle': '2024-1', 'data_location_beamtime_notes': '/tmp', 'data_location_meta': '/tmp', 'data_location_raw': '/tmp', 'data_location_reduced': '/tmp', 'data_location_scratch': '/tmp', 'date': 1730913016, 'detectors': ['other'], 'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'energy_foil': ['Sn'], 'energy_scan_document': 'null', 'experiment_type': ['other'], 'experimenters': 'FleischauerV, WolfordN, ChanB, TerjesenC, FisherY', 'facility': 'CHESS', 'focusing': ['None'], 'furnace': [''], 'in_situ': False, 'insertion_device': ['CCU'], 'material_safety_hazardous_samples': False, 'mechanical_grips': [''], 'mechanical_load_frame': ['RAMSII'], 'mechanical_test': False, 'mechanical_test_type': [''], 'monochromator': ['double_crystal_bragg_si220'], 'pi': 'wolford', 'processing_environment': [''], 'sample_chemical_formula': 'none', 'sample_common_name': 'none', 'sample_geometry': 'none', 'sample_mat_ped_heat_treatment': 'none', 'sample_mat_ped_processing_route': 'none', 'sample_name': 'lup-20kev-1', 'sample_state': [''], 'schema': 'ID3A', 'schema_file': '/Users/vk/Work/CHESS/FOXDEN/FOXDEN/configs/ID3A.json', 'staff_scientist': ['ShanksKS'], 'supplementary_technique': [''], 'technique': ['other'], 'undulator_scan_document': 'null'}] <class 'list'>
PrintProcessor data :
[{'name': 'FoxdenMetaDataProcessor', 'data': [{'_id': '679b74190750c4ed9d2c1918', 'affiliation': ['Industry'], 'alignment': False, 'beam_energy': 312.462, 'beamline': ['3A'], 'beamline_funding_partner': ['CHEXS_NSF'], 'beamline_setup_document': '/tmp', 'btr': 'test-987-b', 'calibration': False, 'calibration_document': '', 'cesr_conditions': ['9x5_bunch_mode'], 'cycle': '2024-1', 'data_location_beamtime_notes': '/tmp', 'data_location_meta': '/tmp', 'data_location_raw': '/tmp', 'data_location_reduced': '/tmp', 'data_location_scratch': '/tmp', 'date': 1730913016, 'detectors': ['other'], 'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'energy_foil': ['Sn'], 'energy_scan_document': 'null', 'experiment_type': ['other'], 'experimenters': 'FleischauerV, WolfordN, ChanB, TerjesenC, FisherY', 'facility': 'CHESS', 'focusing': ['None'], 'furnace': [''], 'in_situ': False, 'insertion_device': ['CCU'], 'material_safety_hazardous_samples': False, 'mechanical_grips': [''], 'mechanical_load_frame': ['RAMSII'], 'mechanical_test': False, 'mechanical_test_type': [''], 'monochromator': ['double_crystal_bragg_si220'], 'pi': 'wolford', 'processing_environment': [''], 'sample_chemical_formula': 'none', 'sample_common_name': 'none', 'sample_geometry': 'none', 'sample_mat_ped_heat_treatment': 'none', 'sample_mat_ped_processing_route': 'none', 'sample_name': 'lup-20kev-1', 'sample_state': [''], 'schema': 'ID3A', 'schema_file': '/Users/vk/Work/CHESS/FOXDEN/FOXDEN/configs/ID3A.json', 'staff_scientist': ['ShanksKS'], 'supplementary_technique': [''], 'technique': ['other'], 'undulator_scan_document': 'null'}], 'schema': None}]
responpse <Response [200]> <class 'requests.models.Response'>
record
 ['/tmp/file1.png', '/tmp/file1.png', '/tmp/file2.png'] <class 'list'>
PrintProcessor data :
[{'name': 'FoxdenProvenanceProcessor', 'data': ['/tmp/file1.png', '/tmp/file1.png', '/tmp/file2.png'], 'schema': None}]
```
Few things to mention here:
- output of FoxdenMetaDataProcessor is a list of found meta-data records
- output of FoxdenProvenanceProcessor is a list of output files associated with given did

In particular, now we can start integration of FoxdenProvenanceProcessor with CHAP pipeline where we can only specify `did` and get list of files back which we can use for further processing within CHAP.