### PR TITLE
Add FOXDEN readers implementation

### DIFF
--- a/CHAP/foxden/__init__.py
+++ b/CHAP/foxden/__init__.py
@@ -1,6 +1,8 @@
 """This subpackage contains pieces for communication with FOXDEN services.
 """
 
-from CHAP.foxden.processor import FoxdenProvenanceProcessor, FoxdenMetaDataProcessor
-from CHAP.foxden.reader import FoxdenReader
+from CHAP.foxden.processor import \
+        FoxdenProvenanceProcessor, FoxdenMetaDataProcessor
+from CHAP.foxden.reader import \
+        FoxdenMetaDataReader, FoxdenProvenanceReader, FoxdenSpecScansReader
 from CHAP.foxden.writer import FoxdenWriter

--- a/CHAP/foxden/processor.py
+++ b/CHAP/foxden/processor.py
@@ -9,12 +9,9 @@ Description: Processor module for FOXDEN services
 
 # System modules
 from time import time
-import json
 
 # Local modules
 from CHAP.processor import Processor
-from CHAP.foxden.writer import FoxdenWriter
-from CHAP.foxden.utils import HttpRequest
 
 class FoxdenMetaDataProcessor(Processor):
     """A Processor to communicate with FOXDEN MetaData server."""
@@ -38,18 +35,6 @@ class FoxdenMetaDataProcessor(Processor):
         t0 = time()
         self.logger.info(
             f'Executing "process" with url={url} data={data} did={did}')
-        rurl = f'{url}/search'
-        request = {"client": "CHAP",
-                   "service_query": {"query": "", "spec": {"did":did},
-                                     "sql": "", "idx": 0, "limit": 0}}
-        payload = json.dumps(request)
-        response = HttpRequest(rurl, payload, method='POST')
-        print("responpse", response, type(response))
-        if response.status_code == 200:
-            data = json.loads(response.text)
-        else:
-            data = []
-        print("record\n", data, type(data))
         self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
         return data
 
@@ -74,20 +59,7 @@ class FoxdenProvenanceProcessor(Processor):
         t0 = time()
         self.logger.info(
             f'Executing "process" with url={url} data={data} did={did}')
-        rurl = f'{url}/files?did={did}'
-        payload = None
-        response = HttpRequest(rurl, payload, method='GET')
-        print("responpse", response, type(response))
-        if response.status_code == 200:
-            data = []
-            # here we received FOXDEN provenance records
-            # we will extract from them only file names
-            # and return to upstream caller
-            for rec in json.loads(response.text):
-                data.append(rec["name"])
-        else:
-            data = []
-        print("record\n", data, type(data))
+        self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
         return data
 
 

--- a/CHAP/foxden/reader.py
+++ b/CHAP/foxden/reader.py
@@ -1,19 +1,42 @@
-"""FOXDEN reader."""
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+#pylint: disable=
+"""
+File       : reader.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: FOXDEN readers
+"""
 
+# system modules
+from time import time
+import json
+
+# 3rd party modules
+import requests
+
+# CHAP modules
 from CHAP.foxden.utils import HttpRequest
+from CHAP.pipeline import PipelineItem
 
 
-class FoxdenReader():
-    """FOXDEN reader reads data from specific FOXDEN service."""
+class FoxdenMetaDataReader(PipelineItem):
+    """FOXDEN MetaData reader reads data from specific FOXDEN MetaData service."""
     def read(
-            self, url, data, method='GET', headers=None,
-            scope='read', timeout=10, dryRun=False):
+            self, url, data, did='', query='', spec=None,
+            method='GET', headers=None,
+            scope='read', timeout=10, dryRun=False, verbose=False):
         """Read data from FOXDEN service
 
-        :param data: Input data.
-        :type data: list[PipelineData]
         :param url: URL of service.
         :type url: str
+        :param data: Input data.
+        :type data: list[PipelineData]
+        :param did: FOXDEN dataset identifier (did)
+        :type did: string, optional
+        :param query: FOXDEN query
+        :type query: string, optional
+        :param spec: FOXDEN spec
+        :type spec: dictionary, optional
         :param method: HTTP method to use, `"POST"` for creation and
             `"PUT"` for update, defaults to `"POST"`.
         :type method: str, optional
@@ -26,10 +49,138 @@ class FoxdenReader():
         :param dryRun: `dryRun` option to verify HTTP workflow,
             defaults to `False`.
         :type dryRun: bool, optional
+        :param verbose: verbose output
+        :type verbose: bool, optional
         :return: Contents of the input data.
         :rtype: object
         """
-        return HttpRequest(url, data, method, headers, scope, timeout, dryrun)
+        t0 = time()
+        self.logger.info(
+            f'Executing "process" with url={url} data={data} did={did}')
+        rurl = f'{url}/search'
+        request = {"client": "CHAP-FoxdenMetaDataReader", "service_query": {}}
+        if did and did != "":
+            request["service_query"].update({"spec": {"did": did}})
+        if query and query != "":
+            request["service_query"].update({"query": query})
+        if spec:
+            request["service_query"].update({"spec": spec})
+        payload = json.dumps(request)
+        if verbose:
+            self.logger.info(f"method=POST url={rurl} payload={payload}")
+        response = HttpRequest(rurl, payload, method='POST')
+        if verbose:
+            self.logger.info(f"code={response.status_code} data={response.text}")
+        if response.status_code == 200:
+            data = json.loads(response.text)
+        else:
+            data = []
+        self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
+        return data
+
+class FoxdenProvenanceReader(PipelineItem):
+    """FOXDEN Provenance reader reads data from specific FOXDEN Provenance service."""
+    def read(
+            self, url, data, did='', method='GET', headers=None,
+            scope='read', timeout=10, dryRun=False, verbose=False):
+        """FOXDEN Provenance processor
+
+        :param url: URL of service.
+        :type url: str
+        :param data: Input data.
+        :type data: list[PipelineData]
+        :param did: FOXDEN dataset identifier (did)
+        :type did: string, optional
+        :param query: FOXDEN query
+        :type query: string, optional
+        :param dryRun: `dryRun` option to verify HTTP workflow,
+            defaults to `False`.
+        :type dryRun: bool, optional
+        :param verbose: verbose output
+        :type verbose: bool, optional
+        :return: data from FOXDEN provenance service
+        :rtype: list of file names
+        """
+        t0 = time()
+        self.logger.info(
+            f'Executing "process" with url={url} data={data} did={did}')
+        rurl = f'{url}/files?did={did}'
+        payload = None
+        if verbose:
+            self.logger.info(f"method=GET url={rurl}")
+        response = HttpRequest(rurl, payload, method='GET')
+        if verbose:
+            self.logger.info(f"code={response.status_code} data={response.text}")
+        if response.status_code == 200:
+            data = []
+            # here we received FOXDEN provenance records
+            # we will extract from them only file names
+            # and return to upstream caller
+            for rec in json.loads(response.text):
+                data.append(rec["name"])
+        else:
+            data = []
+        self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
+        return data
+
+class FoxdenSpecScansReader(PipelineItem):
+    """FOXDEN SpecScans reader reads data from specific FOXDEN SpecScans service."""
+    def read(
+            self, url, data, did='', query='', spec=None,
+            method='GET', headers=None,
+            scope='read', timeout=10, dryRun=False, verbose=False):
+        """Read data from FOXDEN service
+
+        :param url: URL of service.
+        :type url: str
+        :param data: Input data.
+        :type data: list[PipelineData]
+        :param did: FOXDEN dataset identifier (did)
+        :type did: string, optional
+        :param query: FOXDEN query
+        :type query: string, optional
+        :param spec: FOXDEN spec
+        :type spec: dictionary, optional
+        :param method: HTTP method to use, `"POST"` for creation and
+            `"PUT"` for update, defaults to `"POST"`.
+        :type method: str, optional
+        :param headers: HTTP headers to use.
+        :type headers: dictionary, optional
+        :param scope: FOXDEN scope to use, e.g. read or write
+        :type scope: string
+        :param timeout: Timeout of HTTP request, defaults to `10`.
+        :type timeout: str, optional
+        :param dryRun: `dryRun` option to verify HTTP workflow,
+            defaults to `False`.
+        :type dryRun: bool, optional
+        :param verbose: verbose output
+        :type verbose: bool, optional
+        :return: Contents of the input data.
+        :rtype: object
+        """
+        t0 = time()
+        self.logger.info(
+            f'Executing "process" with url={url} data={data} did={did}')
+        rurl = f'{url}/search'
+        request = {"client": "CHAP-FoxdenSpecScansReader", "service_query": {}}
+        if did != "":
+            request["service_query"].update({"spec": {"did": did}})
+        if query != "":
+            request["service_query"].update({"query": query})
+        if spec:
+            request["service_query"].update({"spec": spec})
+        payload = json.dumps(request)
+        if verbose:
+            self.logger.info(f"method=POST url={rurl} payload={payload}")
+        response = HttpRequest(rurl, payload, method='POST')
+        if verbose:
+            self.logger.info(f"code={response.status_code} data={response.text}")
+        if response.status_code == 200:
+            data = json.loads(response.text)
+        else:
+            data = []
+        self.logger.info(f'Finished "process" in {time()-t0:.3f} seconds\n')
+        return data
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR provides code re-factoring, adds FoxdenSpecScansReader, and standardize all FOXDEN readers.

The code has been tested with the following configuration:
```
config:
  inputdir: .
  outputdir: output # Change as desired
  interactive: true # Change as desired
  log_level: INFO
  profile: false

pipeline:
  - foxden.FoxdenMetaDataReader:
      spec:
        did: "/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child"
        beam_energy: 312.462
      url: "http://localhost:8300"
      dryRun: True
  - common.PrintProcessor: {}
  - foxden.FoxdenProvenanceReader:
      did: "/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child"
      url: "http://localhost:8310"
      dryRun: True
      verbose: True
  - common.PrintProcessor: {}
```
Now, we can pass the following options to FOXDEN readers:
- FoxdenMetaDataReader
  - did (string)
  - query (string)
  - spec (dictionary)
- FoxdenProvenanceReader
  - did (string)
- FoxdenSpecScansReader
  - did (string)
  - query (string)
  - spec (dictionary)

### CHAP pipeline output
the CHAP pipeline with FoxdenMetaDataReader and FoxdenProvenanceReader:
```
2025-03-14 13:46:23: CHAP.runner         : INFO: Input pipeline configuration: [{'foxden.FoxdenMetaDataReader': {'spec': {'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'beam_energy': 312.462}, 'url': 'http://localhost:8300', 'dryRun': True}}, {'common.PrintProcessor': {}}, {'foxden.FoxdenProvenanceReader': {'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'url': 'http://localhost:8310', 'dryRun': True, 'verbose': True}}, {'common.PrintProcessor': {}}]

2025-03-14 13:46:23: CHAP.runner         : INFO: Loaded <CHAP.foxden.reader.FoxdenMetaDataReader object at 0x106c49410>
2025-03-14 13:46:23: CHAP.runner         : INFO: Loaded <CHAP.common.processor.PrintProcessor object at 0x11c90c110>
2025-03-14 13:46:23: CHAP.runner         : INFO: Loaded <CHAP.foxden.reader.FoxdenProvenanceReader object at 0x118c33450>
2025-03-14 13:46:23: CHAP.runner         : INFO: Loaded <CHAP.common.processor.PrintProcessor object at 0x118c33c50>
2025-03-14 13:46:23: CHAP.runner         : INFO: Loaded <CHAP.pipeline.Pipeline object at 0x11cc8ca50> with 4 items

2025-03-14 13:46:23: CHAP.runner         : INFO: Calling "execute" on <CHAP.pipeline.Pipeline object at 0x11cc8ca50>
2025-03-14 13:46:23: Pipeline            : INFO: Executing "execute"

2025-03-14 13:46:23: Pipeline            : INFO: Calling "execute" on <CHAP.foxden.reader.FoxdenMetaDataReader object at 0x106c49410>
2025-03-14 13:46:23: FoxdenMetaDataReader: INFO: Executing "read"
2025-03-14 13:46:23: FoxdenMetaDataReader: INFO: Executing "process" with url=http://localhost:8300 data=[] did=
2025-03-14 13:46:23: FoxdenMetaDataReader: INFO: Finished "process" in 0.008 seconds

2025-03-14 13:46:23: FoxdenMetaDataReader: INFO: Finished "read" in 0 seconds

2025-03-14 13:46:23: Pipeline            : INFO: Calling "execute" on <CHAP.common.processor.PrintProcessor object at 0x11c90c110>
2025-03-14 13:46:23: PrintProcessor      : INFO: Executing "process"
2025-03-14 13:46:23: PrintProcessor      : INFO: Finished "process" in 0 seconds

2025-03-14 13:46:23: Pipeline            : INFO: Calling "execute" on <CHAP.foxden.reader.FoxdenProvenanceReader object at 0x118c33450>
2025-03-14 13:46:23: FoxdenProvenanceReader: INFO: Executing "read"
2025-03-14 13:46:23: FoxdenProvenanceReader: INFO: Executing "process" with url=http://localhost:8310 data=[{'name': 'PrintProcessor', 'data': [{'name': 'FoxdenMetaDataReader', 'data': [{'_id': '679b74190750c4ed9d2c1918', 'affiliation': ['Industry'], 'alignment': False, 'beam_energy': 312.462, 'beamline': ['3A'], 'beamline_funding_partner': ['CHEXS_NSF'], 'beamline_setup_document': '/tmp', 'btr': 'test-987-b', 'calibration': False, 'calibration_document': '', 'cesr_conditions': ['9x5_bunch_mode'], 'cycle': '2024-1', 'data_location_beamtime_notes': '/tmp', 'data_location_meta': '/tmp', 'data_location_raw': '/tmp', 'data_location_reduced': '/tmp', 'data_location_scratch': '/tmp', 'date': 1730913016, 'detectors': ['other'], 'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'energy_foil': ['Sn'], 'energy_scan_document': 'null', 'experiment_type': ['other'], 'experimenters': 'FleischauerV, WolfordN, ChanB, TerjesenC, FisherY', 'facility': 'CHESS', 'focusing': ['None'], 'furnace': [''], 'in_situ': False, 'insertion_device': ['CCU'], 'material_safety_hazardous_samples': False, 'mechanical_grips': [''], 'mechanical_load_frame': ['RAMSII'], 'mechanical_test': False, 'mechanical_test_type': [''], 'monochromator': ['double_crystal_bragg_si220'], 'pi': 'wolford', 'processing_environment': [''], 'sample_chemical_formula': 'none', 'sample_common_name': 'none', 'sample_geometry': 'none', 'sample_mat_ped_heat_treatment': 'none', 'sample_mat_ped_processing_route': 'none', 'sample_name': 'lup-20kev-1', 'sample_state': [''], 'schema': 'ID3A', 'schema_file': '/Users/vk/Work/CHESS/FOXDEN/FOXDEN/configs/ID3A.json', 'staff_scientist': ['ShanksKS'], 'supplementary_technique': [''], 'technique': ['other'], 'undulator_scan_document': 'null'}], 'schema': None}], 'schema': None}] did=/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child
2025-03-14 13:46:23: FoxdenProvenanceReader: INFO: method=GET url=http://localhost:8310/files?did=/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child
2025-03-14 13:46:23: FoxdenProvenanceReader: INFO: code=200 data=[
{"checksum":"","create_at":1737744450,"create_by":"Server","did":"/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child","file_type":"input","is_file_valid":1,"modify_at":1737744450,"modify_by":"Server","name":"/tmp/file1.png","size":0}
,{"checksum":"","create_at":1737744450,"create_by":"Server","did":"/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child","file_type":"output","is_file_valid":1,"modify_at":1737744450,"modify_by":"Server","name":"/tmp/file1.png","size":0}
,{"checksum":"","create_at":1737744450,"create_by":"Server","did":"/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child","file_type":"input","is_file_valid":1,"modify_at":1737744450,"modify_by":"Server","name":"/tmp/file2.png","size":0}
]

2025-03-14 13:46:23: FoxdenProvenanceReader: INFO: Finished "process" in 0.002 seconds

2025-03-14 13:46:23: FoxdenProvenanceReader: INFO: Finished "read" in 0 seconds

2025-03-14 13:46:23: Pipeline            : INFO: Calling "execute" on <CHAP.common.processor.PrintProcessor object at 0x118c33c50>
2025-03-14 13:46:23: PrintProcessor      : INFO: Executing "process"
2025-03-14 13:46:23: PrintProcessor      : INFO: Finished "process" in 0 seconds

2025-03-14 13:46:23: Pipeline            : INFO: Executed "execute" in 0.010 seconds
2025-03-14 13:46:23: CHAP.runner         : INFO: Executed "run" in 0.056 seconds
PrintProcessor data :
[{'name': 'FoxdenMetaDataReader', 'data': [{'_id': '679b74190750c4ed9d2c1918', 'affiliation': ['Industry'], 'alignment': False, 'beam_energy': 312.462, 'beamline': ['3A'], 'beamline_funding_partner': ['CHEXS_NSF'], 'beamline_setup_document': '/tmp', 'btr': 'test-987-b', 'calibration': False, 'calibration_document': '', 'cesr_conditions': ['9x5_bunch_mode'], 'cycle': '2024-1', 'data_location_beamtime_notes': '/tmp', 'data_location_meta': '/tmp', 'data_location_raw': '/tmp', 'data_location_reduced': '/tmp', 'data_location_scratch': '/tmp', 'date': 1730913016, 'detectors': ['other'], 'did': '/beamline=3a/btr=test-987-b/cycle=2024-3/sample_name=lup-20kev-1/test=child', 'energy_foil': ['Sn'], 'energy_scan_document': 'null', 'experiment_type': ['other'], 'experimenters': 'FleischauerV, WolfordN, ChanB, TerjesenC, FisherY', 'facility': 'CHESS', 'focusing': ['None'], 'furnace': [''], 'in_situ': False, 'insertion_device': ['CCU'], 'material_safety_hazardous_samples': False, 'mechanical_grips': [''], 'mechanical_load_frame': ['RAMSII'], 'mechanical_test': False, 'mechanical_test_type': [''], 'monochromator': ['double_crystal_bragg_si220'], 'pi': 'wolford', 'processing_environment': [''], 'sample_chemical_formula': 'none', 'sample_common_name': 'none', 'sample_geometry': 'none', 'sample_mat_ped_heat_treatment': 'none', 'sample_mat_ped_processing_route': 'none', 'sample_name': 'lup-20kev-1', 'sample_state': [''], 'schema': 'ID3A', 'schema_file': '/Users/vk/Work/CHESS/FOXDEN/FOXDEN/configs/ID3A.json', 'staff_scientist': ['ShanksKS'], 'supplementary_technique': [''], 'technique': ['other'], 'undulator_scan_document': 'null'}], 'schema': None}]
PrintProcessor data :
[{'name': 'FoxdenProvenanceReader', 'data': ['/tmp/file1.png', '/tmp/file1.png', '/tmp/file2.png'], 'schema': None}]
```