### PR TITLE
fix: rel_height_cutoff>0 in EDD strain analysis not working with scipy

### DIFF
--- a/CHAP/edd/utils.py
+++ b/CHAP/edd/utils.py
@@ -1350,7 +1350,7 @@ def get_spectra_fits(
          'centers_range': detector.centers_range,
          'fwhm_min': detector.fwhm_min, 'fwhm_max': detector.fwhm_max})
     config = {
-#        'code': 'lmfit',
+        'code': 'lmfit',
         'models': models,
 #        'plot': True,
         'num_proc': num_proc,


### PR DESCRIPTION
For now set the fit to be performed using lmfit